### PR TITLE
US131037: Create skeleton for Captions Editor

### DIFF
--- a/capture/d2l-capture-producer/d2l-capture-producer.js
+++ b/capture/d2l-capture-producer/d2l-capture-producer.js
@@ -1,7 +1,10 @@
+import '@brightspace-ui/core/components/tabs/tabs.js';
+import '@brightspace-ui/core/components/tabs/tab-panel.js';
 import '@brightspace-ui/core/components/button/button-icon.js';
 import '@brightspace-ui/core/components/button/button.js';
 import '@brightspace-ui/core/components/colors/colors.js';
 import '@brightspace-ui-labs/media-player/media-player.js';
+import './src/d2l-video-producer-captions.js';
 import './src/d2l-video-producer-chapters.js';
 
 import { Container, Shape, Stage, Text } from '@createjs/easeljs';
@@ -156,15 +159,29 @@ class CaptureProducer extends RtlMixin(InternalLocalizeMixin(LitElement)) {
 						controls
 						src="${this.src}"
 					></d2l-labs-media-player>
-					<d2l-video-producer-chapters
-						.chapters="${this.metadata && this.metadata.chapters}"
-						.defaultLanguage="${this.defaultLanguage}"
-						.selectedLanguage="${this.selectedLanguage}"
-						?loading="${this._loading}"
-						@add-new-chapter="${this._addNewChapter}"
-						@chapters-changed="${this._handleChaptersChanged}"
-						@set-chapter-to-current-time="${this._setChapterToCurrentTime}"
-					></d2l-video-producer-chapters>
+					<d2l-tabs>
+						<d2l-tab-panel
+							selected
+							no-padding
+							text=${this.localize('tableOfContents')}
+						>
+							<d2l-video-producer-chapters
+								.chapters="${this.metadata && this.metadata.chapters}"
+								.defaultLanguage="${this.defaultLanguage}"
+								.selectedLanguage="${this.selectedLanguage}"
+								?loading="${this._loading}"
+								@add-new-chapter="${this._addNewChapter}"
+								@chapters-changed="${this._handleChaptersChanged}"
+								@set-chapter-to-current-time="${this._setChapterToCurrentTime}"
+							></d2l-video-producer-chapters>
+						</d2l-tab-panel>
+						<d2l-tab-panel
+							no-padding
+							text=${this.localize('closedCaptions')}
+						>
+							<d2l-video-producer-captions></d2l-video-producer-captions>
+						</d2l-tab-panel>
+					</d2l-tabs>
 				</div>
 				<div class="d2l-video-producer-timeline">
 					<div id="canvas-container">

--- a/capture/d2l-capture-producer/locales/en.js
+++ b/capture/d2l-capture-producer/locales/en.js
@@ -1,6 +1,7 @@
 export const val = {
 	addNewChapter: 'Add new chapter',
 	chapterTitle: 'Chapter title',
+	closedCaptions: 'Closed Captions',
 	cut: 'Cut',
 	delete: 'Delete',
 	editingOverrides: 'Editing language: {language}',

--- a/capture/d2l-capture-producer/src/d2l-video-producer-captions.js
+++ b/capture/d2l-capture-producer/src/d2l-video-producer-captions.js
@@ -1,0 +1,26 @@
+import '@brightspace-ui/core/components/colors/colors.js';
+import { css, html, LitElement } from 'lit-element/lit-element.js';
+import { InternalLocalizeMixin } from './internal-localize-mixin.js';
+
+class VideoProducerCaptions extends InternalLocalizeMixin(LitElement) {
+	static get styles() {
+		return css`
+			.d2l-video-producer-captions {
+				border: 1px solid var(--d2l-color-mica);
+				box-sizing: border-box;
+				position: relative;
+				width: 360px;
+				height: 532px;
+			}
+		`;
+	}
+
+	render() {
+		return html`
+			<div class="d2l-video-producer-captions">
+			</div>
+		`;
+	}
+}
+
+customElements.define('d2l-video-producer-captions', VideoProducerCaptions);

--- a/capture/d2l-capture-producer/src/d2l-video-producer-chapters.js
+++ b/capture/d2l-capture-producer/src/d2l-video-producer-chapters.js
@@ -27,7 +27,7 @@ class VideoProducerChapters extends InternalLocalizeMixin(LitElement) {
 			.d2l-video-producer-chapters {
 				border: 1px solid var(--d2l-color-mica);
 				box-sizing: border-box;
-				height: 580px;
+				height: 532px;
 				position: relative;
 				width: 360px;
 			}
@@ -44,7 +44,7 @@ class VideoProducerChapters extends InternalLocalizeMixin(LitElement) {
 			.d2l-video-producer-chapters-container {
 				display: flex;
 				flex-direction: column;
-				height: 440px;
+				height: 423px;
 				overflow-y: scroll;
 				padding: 10px;
 				position: relative;
@@ -95,7 +95,6 @@ class VideoProducerChapters extends InternalLocalizeMixin(LitElement) {
 		return html`
 			<div class="d2l-video-producer-chapters">
 				<h3 class="d2l-heading-3 d2l-video-producer-chapters-heading">
-					${this.localize('tableOfContents')}
 					<div class="d2l-body-small ${this._editingOverrides ? '' : 'hidden'}">
 						${this.localize('editingOverrides', { language: this.selectedLanguage && this.selectedLanguage.name })}
 					</div>


### PR DESCRIPTION
Adds a tab selector to Producer, along with a new tab panel for Closed Captions. The Closed Captions tab has no contents or functionality yet.

<img width="1199" alt="Captions Editor X - Skeleton" src="https://user-images.githubusercontent.com/9592685/131400436-d7da008d-c6ae-43e8-9fa2-4e12500213fb.png">

<img width="1190" alt="Captions Editor X - Skeleton (Table of Contents tab)" src="https://user-images.githubusercontent.com/9592685/131400765-051ce71f-536f-4393-9bf4-8afa1c723a66.png">
