### PR TITLE
US131039: Use new Producer component in Capture Central

### DIFF
--- a/applications/d2l-capture-central/src/pages/producer/d2l-capture-central-producer.js
+++ b/applications/d2l-capture-central/src/pages/producer/d2l-capture-central-producer.js
@@ -5,6 +5,7 @@ import '@brightspace-ui/core/components/breadcrumbs/breadcrumbs.js';
 import '@brightspace-ui-labs/video-producer/src/video-producer.js';
 import '@brightspace-ui-labs/video-producer/src/video-producer-language-selector.js';
 import '@brightspace-ui/core/components/loading-spinner/loading-spinner.js';
+import '../../../../../capture/d2l-capture-producer.js';
 
 import { css, html } from 'lit-element/lit-element.js';
 import { autorun } from 'mobx';
@@ -136,13 +137,13 @@ class D2LCaptureCentralProducer extends DependencyRequester(PageViewElement) {
 					</d2l-button>
 				</div>
 
-				<d2l-labs-video-producer
+				<d2l-capture-producer
 					.defaultLanguage="${this._defaultLanguage}"
 					.metadata="${this._metadata}"
 					.selectedLanguage="${this._selectedLanguage}"
 					@metadata-changed="${this._handleMetadataChanged}"
 					src="${this._sourceUrl}"
-				></d2l-labs-video-producer>
+				></d2l-capture-producer>
 
 				<d2l-alert-toast type="${this.errorOccurred ? 'error' : 'default'}">
 					${this._alertMessage}

--- a/capture/d2l-capture-producer/src/d2l-video-producer-captions.js
+++ b/capture/d2l-capture-producer/src/d2l-video-producer-captions.js
@@ -283,8 +283,14 @@ class VideoProducerCaptions extends InternalLocalizeMixin(LitElement) {
 	// <script> tags must be added via Javascript in LitElement.
 	// https://stackoverflow.com/a/55693185
 	_appendVttScript() {
+		// Using a relative path (e.g. './scripts/vtt.min.js') in the <script> tag
+		// won't work because the script is on a separate domain from the LMS page.
+		// So we need to construct the absolute URL to the vtt script.
+		const urlOfThisFile = new URL(import.meta.url);
+		const vttScriptUrlPrefix = urlOfThisFile.href.slice(0, urlOfThisFile.href.indexOf('src'));
+
 		const script = document.createElement('script');
-		script.src = '../scripts/vtt.min.js';
+		script.src = `${vttScriptUrlPrefix}scripts/vtt.min.js`;
 		return script;
 	}
 


### PR DESCRIPTION
Previously, Capture Central was still using the deprecated [video-producer in D2L Labs](https://github.com/BrightspaceUILabs/video-producer). This PR updates Capture Central's Producer page to use the new Producer component within this repo.