### PR TITLE
Hide error message element in d2l-content-uploader if there is no err…

### DIFF
--- a/core/d2l-content-uploader/src/components/upload.js
+++ b/core/d2l-content-uploader/src/components/upload.js
@@ -51,6 +51,10 @@ export class Upload extends RtlMixin(RequesterMixin(InternalLocalizeMixin(LitEle
 				background-color: var(--d2l-color-gypsum);
 				border: 2px dashed var(--d2l-color-feedback-error);
 			}
+			.file-drop-content-container {
+				text-align: center;
+				margin: 1.5rem 0;
+			}
 			#file-select {
 				display: none;
 			}
@@ -106,7 +110,7 @@ export class Upload extends RtlMixin(RequesterMixin(InternalLocalizeMixin(LitEle
 		return html`
 			<div class="upload-container">
 				<file-drop @filedrop=${this.onFileDrop} accept=${this._supportedMimeTypes.join(',')}>
-					<center>
+					<div class="file-drop-content-container">
 						<h2 class="d2l-heading-2">${this.localize('dropAudioVideoFile')}</h2>
 						<p class="d2l-body-standard">${this.localize('or')}</p>
 						<d2l-button
@@ -122,8 +126,8 @@ export class Upload extends RtlMixin(RequesterMixin(InternalLocalizeMixin(LitEle
 							/>
 						</d2l-button>
 						<p id="file-size-limit" class="d2l-body-small">${this.localize('fileLimit1Gb')}</p>
-						<p id="error-message" class="d2l-body-compact">${this.errorMessage}&nbsp;</p>
-					</center>
+						${this.errorMessage ? html`<p id="error-message" class="d2l-body-compact">${this.errorMessage}&nbsp;</p>` : ''}
+					</div>
 				</file-drop>
 				<div class="upload-options-container">
 					${this._renderAutoCaptionsOption()}


### PR DESCRIPTION
…or message.

Replace center tag with div with text-align: center (center not supported in html5).


Without error message:
<img width="747" alt="withoutErrorMessage" src="https://user-images.githubusercontent.com/37313128/134701279-bb331a6b-385d-454b-85ee-06d9e6685559.png">


With error message:
<img width="748" alt="withErrorMessage" src="https://user-images.githubusercontent.com/37313128/134701304-5a8cf332-dbe0-4e68-9c3b-9694d7be8874.png">


