### PR TITLE
US131578: Fix captions upload hanging after loading existing captions

### DIFF
--- a/capture/d2l-capture-producer/d2l-capture-producer.js
+++ b/capture/d2l-capture-producer/d2l-capture-producer.js
@@ -926,7 +926,13 @@ class CaptureProducer extends RtlMixin(InternalLocalizeMixin(LitElement)) {
 		this._captionsLoading = true;
 		this._unsavedChanges = true;
 		const localVttUrl = window.URL.createObjectURL(new Blob([e.detail.vttString], { type: 'text/vtt' }));
-		this._captionsUrl = localVttUrl;
+		// Media Player's onSlotChange might not execute if the <track> slot's attributes change.
+		// To force it to execute, we need to temporarily remove the slot and re-add it.
+		// In render(), we hide the <track> slot when _captionsUrl is falsy.
+		this._captionsUrl = '';
+		setTimeout(() => {
+			this._captionsUrl = localVttUrl;
+		}, 500);
 	}
 
 	_handleChaptersChanged(e) {

--- a/capture/d2l-capture-producer/d2l-capture-producer.js
+++ b/capture/d2l-capture-producer/d2l-capture-producer.js
@@ -932,7 +932,7 @@ class CaptureProducer extends RtlMixin(InternalLocalizeMixin(LitElement)) {
 		this._captionsUrl = '';
 		setTimeout(() => {
 			this._captionsUrl = localVttUrl;
-		}, 500);
+		}, 0);
 	}
 
 	_handleChaptersChanged(e) {


### PR DESCRIPTION
When captions are uploaded, we add a `<track>` slot under the Media Player that points to a temporary URL for the captions data. If the `<track>` slot already exists, we simply update its `src` attribute.

However, as per the Web Component specifications, changing a slot's attributes won't fire the `slotchange` event. This causes captions upload to hang, as Media Player listens for `slotchange` before loading and parsing captions.

To ensure that `slotchange` is always fired on upload, this PR removes and re-adds the `<track>` slot during the upload process.