### PR TITLE
US131578: Publish draft captions when Finishing a revision

### DIFF
--- a/capture/d2l-capture-producer/d2l-capture-producer.js
+++ b/capture/d2l-capture-producer/d2l-capture-producer.js
@@ -964,8 +964,13 @@ class CaptureProducer extends RtlMixin(InternalLocalizeMixin(LitElement)) {
 		await this.apiClient.updateCaptions({
 			contentId: this._content.id,
 			captionsVttText: convertTextTrackCueListToVttText(this._captions),
+			draft: true,
 			revisionId: 'latest',
 			locale: this._selectedLanguage.code
+		});
+		await this.apiClient.publishDraftCaptions({
+			contentId: this._content.id,
+			revisionId: 'latest',
 		});
 		const { id, ...revision } = this._revisionsLatestToOldest[0];
 		let newRevision;

--- a/capture/d2l-capture-producer/src/content-service-client.js
+++ b/capture/d2l-capture-producer/src/content-service-client.js
@@ -101,6 +101,16 @@ export default class ContentServiceClient {
 		});
 	}
 
+	publishDraftCaptions({
+		contentId,
+		revisionId,
+	}) {
+		return this._fetch({
+			path: `/api/${this.tenantId}/content/${contentId}/revisions/${revisionId}/captions/drafts/publish`,
+			method: 'POST',
+		});
+	}
+
 	updateCaptions({ contentId, revisionId, draft = false, locale, captionsVttText }) {
 		return this._fetch({
 			path: `/api/${this.tenantId}/content/${contentId}/revisions/${revisionId}/captions/${locale}`,


### PR DESCRIPTION
This uses the new API route from https://github.com/Brightspace/d2l-content-service/pull/1703.