### PR TITLE
Uploader creates content with sharedWith attribute

### DIFF
--- a/core/d2l-content-uploader/src/components/main.js
+++ b/core/d2l-content-uploader/src/components/main.js
@@ -21,6 +21,7 @@ export class Main extends MobxReactionUpdate(ProviderMixin(LitElement)) {
 		return {
 			apiEndpoint: { type: String, attribute: 'api-endpoint' },
 			tenantId: { type: String, attribute: 'tenant-id' },
+			orgUnitId: { type: String, attribute: 'org-unit-id' },
 			value: { type: String, reflect: true },
 			filename: { type: String, reflect: true },
 
@@ -54,7 +55,8 @@ export class Main extends MobxReactionUpdate(ProviderMixin(LitElement)) {
 
 		const apiClient = new ContentServiceClient({
 			endpoint: this.apiEndpoint,
-			tenantId: this.tenantId
+			tenantId: this.tenantId,
+			orgUnitId: this.orgUnitId
 		});
 		this.provideInstance('content-service-client', apiClient);
 

--- a/core/d2l-content-uploader/src/util/content-service-client.js
+++ b/core/d2l-content-uploader/src/util/content-service-client.js
@@ -8,10 +8,12 @@ d2lfetch.use({ name: 'auth', fn: auth });
 export default class ContentServiceClient {
 	constructor({
 		endpoint,
-		tenantId
+		tenantId,
+		orgUnitId
 	}) {
 		this.endpoint = endpoint;
 		this.tenantId = tenantId;
+		this.orgUnitId = orgUnitId;
 	}
 
 	createContent(body) {
@@ -21,6 +23,7 @@ export default class ContentServiceClient {
 			body: {
 				...body,
 				clientApp: 'LmsContent',
+				...this.orgUnitId && {sharedWith: [`ou:${this.orgUnitId}`]}
 			},
 		});
 	}


### PR DESCRIPTION
Content uploaded this way is missing org unit context.

![upload-shared-with](https://user-images.githubusercontent.com/22655/136459466-d8304f7a-f3fa-42df-95a2-586976de8217.png)
