### PR TITLE
fix: Make backwards compatible with v2

### DIFF
--- a/core/d2l-content-viewer/d2l-content-viewer.js
+++ b/core/d2l-content-viewer/d2l-content-viewer.js
@@ -19,6 +19,9 @@ class ContentViewer extends LitElement {
 			framed: { type: Boolean, value: false, attribute: 'framed' },
 			orgUnitId: { type: Number, attribute: 'org-unit-id' },
 			topicId: { type: Number, attribute: 'topic-id' },
+			// href and captions-href deprecated, use orgUnitId and topicId instead
+			href: { type: String, attribute: 'href' },
+			captionsHref: { type: String, attribute: 'captions-href' }
 		};
 	}
 
@@ -88,7 +91,7 @@ class ContentViewer extends LitElement {
 
 		const captionSignedUrls = this.activity
 			? await this.hmClient.getCaptions(this._resourceEntity)
-			: await this.client.getCaptions();
+			: await this.client.getCaptions(this.captionsHref);
 
 		if (captionSignedUrls) {
 			// This forces a slot change event for the media player so it can render the new captions
@@ -107,6 +110,8 @@ class ContentViewer extends LitElement {
 		if (this.activity) {
 			const { src } = await this.hmClient.getMedia(this._resourceEntity);
 			this._mediaSources = [{src, format: 'HD'}];
+		} else if (this.href) {
+			this._mediaSources = [await this._getMediaSource()];
 		} else {
 			const revision = await this.client.getRevision();
 
@@ -140,7 +145,7 @@ class ContentViewer extends LitElement {
 
 	async _getMediaSource(format) {
 		return {
-			src: (await this.client.getDownloadUrl({format})).Value,
+			src: (await this.client.getDownloadUrl({format, href: this.href})).Value,
 			format,
 		};
 	}

--- a/core/d2l-content-viewer/src/clients/rest-client.js
+++ b/core/d2l-content-viewer/src/clients/rest-client.js
@@ -16,16 +16,16 @@ export default class ContentServiceClient {
 		});
 	}
 
-	getCaptions() {
+	getCaptions(captionsHref) {
 		return this._fetch({
-			path: `/d2l/le/content/contentservice/resources/${this.orgUnitId}/topics/${this.topicId}/getCaptions`
+			path: captionsHref || `/d2l/le/content/contentservice/resources/${this.orgUnitId}/topics/${this.topicId}/getCaptions`
 		});
 	}
-	getDownloadUrl({format}) {
+	getDownloadUrl({format, href}) {
 		return this._fetch({
-			path: `/d2l/le/content/contentservice/resources/${this.orgUnitId}/topics/${this.topicId}/download`,
+			path: href || `/d2l/le/content/contentservice/resources/${this.orgUnitId}/topics/${this.topicId}/download`,
 			query: {
-				format: format.value
+				format: format?.value
 			},
 			doNotUseCache: false
 		});


### PR DESCRIPTION
I didn't realize that this repo was doing auto-versioning, so in my previous PR, my change to v3 in package.json didn't get applied. I could either revert that PR or make it backwards compatible, and making it backwards compatible is easy, so I went with that option. This PR just adds back support for the old d2l-content-viewer params `href` and `captions-href`. We can remove support later when we bump to v3.