### PR TITLE
fix: Prevent null error when seeking while timeline is disabled

### DIFF
--- a/capture/d2l-capture-producer/d2l-capture-producer-editor.js
+++ b/capture/d2l-capture-producer/d2l-capture-producer-editor.js
@@ -1182,6 +1182,11 @@ class CaptureProducerEditor extends RtlMixin(InternalLocalizeMixin(LitElement)) 
 	}
 
 	_updateVideoTime() {
+		// If the timeline is disabled for the current file format, do nothing.
+		if (!this.enableCutsAndChapters) {
+			return;
+		}
+
 		// Clear the seeked time once the video has caught up
 		if (this._mouseTime && Math.abs(this._mouseTime - this._mediaPlayer.currentTime) < 1) {
 			this._mouseTime = null;


### PR DESCRIPTION
When the user seeks to a new time position in the audio/video file, the timeline is automatically updated to match.

However, this was causing a null reference error for audio files, because the timeline is not initialized for formats that don't yet support cuts and chapters.