### PR TITLE
fix: Cosmetic fixes in Producer X

### DIFF
--- a/capture/d2l-capture-producer/d2l-capture-producer-editor.js
+++ b/capture/d2l-capture-producer/d2l-capture-producer-editor.js
@@ -36,6 +36,7 @@ class CaptureProducerEditor extends RtlMixin(InternalLocalizeMixin(LitElement)) 
 			metadataLoading: { type: Boolean, attribute: 'metadata-loading' },
 			selectedLanguage: { type: Object },
 			src: { type: String },
+			timelineVisible: { type: Boolean, attribute: 'timeline-visible' },
 
 			_activeCue: { type: Object, attribute: false },
 			_zoomMultiplier: { type: Number, attribute: false },
@@ -147,6 +148,7 @@ class CaptureProducerEditor extends RtlMixin(InternalLocalizeMixin(LitElement)) 
 
 		this.metadata = { cuts: [], chapters: [] };
 		this.metadataLoading = true;
+		this.timelineVisible = false;
 		this.src = '';
 		this.languages = [];
 		this.defaultLanguage = {};
@@ -235,7 +237,7 @@ class CaptureProducerEditor extends RtlMixin(InternalLocalizeMixin(LitElement)) 
 					</d2l-tabs>
 				</div>
 				${(this.enableCutsAndChapters ? html`
-					<div class="d2l-video-producer-timeline" style="visibility: ${this.metadataLoading ? 'hidden' : 'visible'};">
+					<div class="d2l-video-producer-timeline" style="visibility: ${this.timelineVisible ? 'visible' : 'hidden'};">
 						<div id="canvas-container">
 							<canvas height="${constants.CANVAS_HEIGHT}px" width="${constants.CANVAS_WIDTH}px" id="timeline-canvas"></canvas>
 							<div id="zoom-multiplier" style=${styleMap(zoomMultiplierStyleMap)}>

--- a/capture/d2l-capture-producer/d2l-capture-producer-editor.js
+++ b/capture/d2l-capture-producer/d2l-capture-producer-editor.js
@@ -246,8 +246,8 @@ class CaptureProducerEditor extends RtlMixin(InternalLocalizeMixin(LitElement)) 
 							</div>
 						</div>
 						<div class="d2l-video-producer-timeline-controls">
-							<d2l-button-icon @click="${this._changeToSeekMode}" text="${this.localize(constants.CONTROL_MODES.SEEK)}" icon="tier1:divider-solid"></d2l-button-icon>
-							<d2l-button-icon @click="${this._changeToMarkMode}" text="${this.localize(constants.CONTROL_MODES.MARK)}" icon="tier1:edit"></d2l-button-icon>
+							<d2l-button-icon @click="${this._changeToSeekMode}" text="${this.localize(constants.CONTROL_MODES.SEEK)}" icon="tier1:arrow-thin-up"></d2l-button-icon>
+							<d2l-button-icon @click="${this._changeToMarkMode}" text="${this.localize(constants.CONTROL_MODES.MARK)}" icon="tier1:divider-solid"></d2l-button-icon>
 							<d2l-button-icon @click="${this._changeToCutMode}" text="${this.localize(constants.CONTROL_MODES.CUT)}" icon="html-editor:cut"></d2l-button-icon>
 						</div>
 					</div>

--- a/capture/d2l-capture-producer/d2l-capture-producer-editor.js
+++ b/capture/d2l-capture-producer/d2l-capture-producer-editor.js
@@ -183,7 +183,6 @@ class CaptureProducerEditor extends RtlMixin(InternalLocalizeMixin(LitElement)) 
 						controls
 						crossorigin="anonymous"
 						@cuechange="${this._handleCueChange}"
-						hideseekbar
 						hide-seek-bar
 						@pause="${this._pauseUpdatingVideoTime}"
 						@play="${this._startUpdatingVideoTime}"

--- a/capture/d2l-capture-producer/d2l-capture-producer-editor.js
+++ b/capture/d2l-capture-producer/d2l-capture-producer-editor.js
@@ -183,6 +183,8 @@ class CaptureProducerEditor extends RtlMixin(InternalLocalizeMixin(LitElement)) 
 						controls
 						crossorigin="anonymous"
 						@cuechange="${this._handleCueChange}"
+						hideseekbar
+						hide-seek-bar
 						@pause="${this._pauseUpdatingVideoTime}"
 						@play="${this._startUpdatingVideoTime}"
 						@seeking="${this._updateVideoTime}"

--- a/capture/d2l-capture-producer/d2l-capture-producer.js
+++ b/capture/d2l-capture-producer/d2l-capture-producer.js
@@ -48,6 +48,7 @@ class CaptureProducer extends RtlMixin(InternalLocalizeMixin(LitElement)) {
 			_selectedLanguage: { type: Object, attribute: false },
 			_selectedRevisionIndex: { type: Number, attribute: false },
 			_src: { type: String, attribute: false },
+			_timelineVisible: { type: Boolean, attribute: false },
 			_unsavedChanges: { type: String, attribute: false },
 			_mediaLoaded: { type: Boolean, attribute: false },
 		};
@@ -59,12 +60,10 @@ class CaptureProducer extends RtlMixin(InternalLocalizeMixin(LitElement)) {
 				align-items: center;
 				display: flex;
 				flex-direction: column;
-				height: 70%;
 				justify-content: center;
+				margin-top: 100px;
 				overflow-y: hidden;
-				position: absolute;
 				width: 100%;
-				z-index: 99;
 			}
 
 			.d2l-video-producer-processing-message {
@@ -239,6 +238,7 @@ class CaptureProducer extends RtlMixin(InternalLocalizeMixin(LitElement)) {
 					.selectedLanguage="${this._selectedLanguage}"
 					.src="${this._src}"
 					style="visibility: ${(this._loading || this._isProcessing) ? 'hidden' : 'visible'};"
+					?timeline-visible="${this._timelineVisible}"
 				></d2l-capture-producer-editor>
 				<d2l-alert-toast type="${this._errorOccurred ? 'error' : 'default'}">
 					${this._alertMessage}
@@ -750,6 +750,10 @@ class CaptureProducer extends RtlMixin(InternalLocalizeMixin(LitElement)) {
 		});
 		this._selectedLanguage = this._languages.find(language => language.isDefault);
 		this._defaultLanguage = this._selectedLanguage;
+	}
+
+	get _timelineVisible() {
+		return this._enableCutsAndChapters && !this.loading && !this._metadataLoading;
 	}
 
 	get _unsavedChanges() {

--- a/capture/d2l-capture-producer/d2l-capture-producer.js
+++ b/capture/d2l-capture-producer/d2l-capture-producer.js
@@ -58,12 +58,15 @@ class CaptureProducer extends RtlMixin(InternalLocalizeMixin(LitElement)) {
 		return [bodyStandardStyles, labelStyles, selectStyles, css`
 			.d2l-video-producer-overlay {
 				align-items: center;
+				bottom: 0px;
 				display: flex;
 				flex-direction: column;
 				justify-content: center;
-				margin-top: 100px;
+				left: 0px;
 				overflow-y: hidden;
-				width: 100%;
+				position: absolute;
+				right: 0px;
+				top: 0px;
 			}
 
 			.d2l-video-producer-processing-message {

--- a/capture/d2l-capture-producer/demo/demo-video-producer.js
+++ b/capture/d2l-capture-producer/demo/demo-video-producer.js
@@ -212,6 +212,7 @@ class DemoVideoProducer extends LitElement {
 					@metadata-changed="${this._handleMetadataChanged}"
 					.selectedLanguage="${this.selectedLanguage}"
 					.src="${this._videoSelected ? VIDEO_SOURCE : AUDIO_SOURCE}"
+					?timeline-visible="${this._videoSelected && !this._metadataLoading}"
 				></d2l-capture-producer-editor>
 
 				<d2l-alert-toast type="default">

--- a/capture/d2l-capture-producer/src/d2l-video-producer-captions.js
+++ b/capture/d2l-capture-producer/src/d2l-video-producer-captions.js
@@ -79,6 +79,7 @@ class CaptionsCueListItem extends InternalLocalizeMixin(LitElement) {
 				align-items: center;
 				display: grid;
 				justify-content: space-between;
+				padding-left: 2px;
 				width: 100%;
 			}
 


### PR DESCRIPTION
- Fixed a bug where Producer's loading overlay was wider than Producer itself, causing the loading spinner to appear on the right edge of the page instead of the center.
- Fixed a bug where the timeline would appear before Producer finished loading.
- In the captions cue list item layout, the "Start" and "End" labels are now horizontally aligned with the edge of the text input box.
- To prevent confusing the user with two progress bars (Producer's timeline and Media Player's seek bar), Producer passes a `hide-seek-bar` attribute to the Media Player. This attribute will be implemented in a followup PR in the Media Player repo: https://github.com/BrightspaceUILabs/media-player/pull/114