### PR TITLE
feat: Use the Content Service's Resource Model in Producer X

### DIFF
--- a/capture/d2l-capture-producer/d2l-capture-producer.js
+++ b/capture/d2l-capture-producer/d2l-capture-producer.js
@@ -352,8 +352,8 @@ class CaptureProducer extends RtlMixin(InternalLocalizeMixin(LitElement)) {
 			draftToPublish = this._latestDraftRevision;
 		}
 
-		if (this._unsavedChanges) {
-			if (this._enableCutsAndChapters) {
+		try {
+			if (this._metadataChanged) {
 				await this.apiClient.updateMetadata({
 					contentId: this._content.id,
 					metadata: this._metadata,
@@ -361,16 +361,15 @@ class CaptureProducer extends RtlMixin(InternalLocalizeMixin(LitElement)) {
 				});
 				this._metadataChanged = false;
 			}
-			await this.apiClient.updateCaptions({
-				contentId: this._content.id,
-				captionsVttText: convertVttCueArrayToVttText(this._captions),
-				revisionId: draftToPublish.id,
-				locale: this._selectedLanguage.code
-			});
-			this._captionsChanged = false;
-		}
-
-		try {
+			if (this._captionsChanged) {
+				await this.apiClient.updateCaptions({
+					contentId: this._content.id,
+					captionsVttText: convertVttCueArrayToVttText(this._captions),
+					revisionId: draftToPublish.id,
+					locale: this._selectedLanguage.code
+				});
+				this._captionsChanged = false;
+			}
 			await this.apiClient.processRevision({
 				contentId: this._content.id,
 				revisionId: draftToPublish.id,
@@ -501,7 +500,7 @@ class CaptureProducer extends RtlMixin(InternalLocalizeMixin(LitElement)) {
 		}
 
 		try {
-			if (this._enableCutsAndChapters) {
+			if (this._metadataChanged) {
 				await this.apiClient.updateMetadata({
 					contentId: this._content.id,
 					metadata: this._metadata,
@@ -509,13 +508,15 @@ class CaptureProducer extends RtlMixin(InternalLocalizeMixin(LitElement)) {
 				});
 				this._metadataChanged = false;
 			}
-			await this.apiClient.updateCaptions({
-				contentId: this._content.id,
-				captionsVttText: convertVttCueArrayToVttText(this._captions),
-				revisionId: this._latestDraftRevision.id,
-				locale: this._selectedLanguage.code
-			});
-			this._captionsChanged = false;
+			if (this._captionsChanged) {
+				await this.apiClient.updateCaptions({
+					contentId: this._content.id,
+					captionsVttText: convertVttCueArrayToVttText(this._captions),
+					revisionId: this._latestDraftRevision.id,
+					locale: this._selectedLanguage.code
+				});
+				this._captionsChanged = false;
+			}
 		} catch (error) {
 			this._errorOccurred = true;
 		}

--- a/capture/d2l-capture-producer/d2l-capture-producer.js
+++ b/capture/d2l-capture-producer/d2l-capture-producer.js
@@ -365,13 +365,7 @@ class CaptureProducer extends RtlMixin(InternalLocalizeMixin(LitElement)) {
 				this._metadataChanged = false;
 			}
 			if (this._captionsChanged) {
-				await this.apiClient.updateCaptions({
-					contentId: this._content.id,
-					captionsVttText: convertVttCueArrayToVttText(this._captions),
-					revisionId: draftToPublish.id,
-					locale: this._selectedLanguage.code
-				});
-				this._captionsChanged = false;
+				await this._saveCaptions(draftToPublish);
 			}
 			await this.apiClient.processRevision({
 				contentId: this._content.id,
@@ -512,13 +506,7 @@ class CaptureProducer extends RtlMixin(InternalLocalizeMixin(LitElement)) {
 				this._metadataChanged = false;
 			}
 			if (this._captionsChanged) {
-				await this.apiClient.updateCaptions({
-					contentId: this._content.id,
-					captionsVttText: convertVttCueArrayToVttText(this._captions),
-					revisionId: this._latestDraftRevision.id,
-					locale: this._selectedLanguage.code
-				});
-				this._captionsChanged = false;
+				await this._saveCaptions(this._latestDraftRevision);
 			}
 		} catch (error) {
 			this._errorOccurred = true;
@@ -727,6 +715,24 @@ class CaptureProducer extends RtlMixin(InternalLocalizeMixin(LitElement)) {
 			</p>
 			<d2l-icon class="d2l-video-producer-saved-unsaved-indicator-icon" icon="${icon}" style="color: ${feedbackColor};"></d2l-icon>
 		  </div>`;
+	}
+
+	async _saveCaptions(revision) {
+		if (this._captions?.length > 0) {
+			await this.apiClient.updateCaptions({
+				contentId: this._content.id,
+				captionsVttText: convertVttCueArrayToVttText(this._captions),
+				revisionId: revision.id,
+				locale: this._selectedLanguage.code,
+			});
+		} else {
+			await this.apiClient.deleteCaptions({
+				contentId: this._content.id,
+				revisionId: revision.id,
+				locale: this._selectedLanguage.code,
+			});
+		}
+		this._captionsChanged = false;
 	}
 
 	get _saveIsDisabled() {

--- a/capture/d2l-capture-producer/d2l-capture-producer.js
+++ b/capture/d2l-capture-producer/d2l-capture-producer.js
@@ -605,7 +605,7 @@ class CaptureProducer extends RtlMixin(InternalLocalizeMixin(LitElement)) {
 				locale,
 				draft: true,
 			});
-			this._captionsUrl = res.captionsUrl;
+			this._captionsUrl = res.value;
 		} catch (error) {
 			if (error.message === 'Not Found') {
 				this._captions = [];

--- a/capture/d2l-capture-producer/src/content-service-client.js
+++ b/capture/d2l-capture-producer/src/content-service-client.js
@@ -24,6 +24,14 @@ export default class ContentServiceClient {
 		});
 	}
 
+	deleteCaptions({ contentId, revisionId, locale, adjusted = false }) {
+		return this._fetch({
+			path: `/api/${this.tenantId}/content/${contentId}/revisions/${revisionId}/resources/captions`,
+			method: 'DELETE',
+			query: { locale, adjusted },
+		});
+	}
+
 	deleteMetadata({ contentId, revisionId }) {
 		return this._fetch({
 			path: `/api/${this.tenantId}/content/${contentId}/revisions/${revisionId}/resources/metadata`,

--- a/capture/d2l-capture-producer/src/content-service-client.js
+++ b/capture/d2l-capture-producer/src/content-service-client.js
@@ -26,7 +26,7 @@ export default class ContentServiceClient {
 
 	deleteMetadata({ contentId, revisionId }) {
 		return this._fetch({
-			path: `/api/${this.tenantId}/content/${contentId}/revisions/${revisionId}/metadata`,
+			path: `/api/${this.tenantId}/content/${contentId}/revisions/${revisionId}/resources/metadata`,
 			method: 'DELETE',
 		});
 	}
@@ -42,13 +42,13 @@ export default class ContentServiceClient {
 		return `Content Service Client: ${this.endpoint}`;
 	}
 
-	async getCaptionsUrl({ contentId, revisionId, locale }) {
+	async getCaptionsUrl({ contentId, revisionId, locale, adjusted = false }) {
 		const headers = new Headers();
 		headers.append('pragma', 'no-cache');
 		headers.append('cache-control', 'no-cache');
 		return await this._fetch({
-			path: `/api/${this.tenantId}/content/${contentId}/revisions/${revisionId}/captions/${locale}`,
-			query: { urlOnly: true, exact: true },
+			path: `/api/${this.tenantId}/content/${contentId}/revisions/${revisionId}/resources/captions/signed-url`,
+			query: { locale, exact: true, adjusted },
 			headers
 		});
 	}
@@ -68,7 +68,7 @@ export default class ContentServiceClient {
 		headers.append('pragma', 'no-cache');
 		headers.append('cache-control', 'no-cache');
 		return this._fetch({
-			path: `/api/${this.tenantId}/content/${contentId}/revisions/${revisionId}/metadata`,
+			path: `/api/${this.tenantId}/content/${contentId}/revisions/${revisionId}/resources/metadata/file-content`,
 			headers
 		});
 	}
@@ -114,10 +114,11 @@ export default class ContentServiceClient {
 		});
 	}
 
-	updateCaptions({ contentId, revisionId, locale, captionsVttText }) {
+	updateCaptions({ contentId, revisionId, locale, captionsVttText, adjusted = false }) {
 		return this._fetch({
-			path: `/api/${this.tenantId}/content/${contentId}/revisions/${revisionId}/captions/${locale}`,
+			path: `/api/${this.tenantId}/content/${contentId}/revisions/${revisionId}/resources/captions`,
 			method: 'PUT',
+			query: { locale, adjusted },
 			body: captionsVttText,
 			contentType: 'text/vtt',
 			extractJsonBody: false // The PUT captions route returns no content (status 204)
@@ -134,7 +135,7 @@ export default class ContentServiceClient {
 
 	updateMetadata({ contentId, revisionId, metadata }) {
 		return this._fetch({
-			path: `/api/${this.tenantId}/content/${contentId}/revisions/${revisionId}/metadata`,
+			path: `/api/${this.tenantId}/content/${contentId}/revisions/${revisionId}/resources/metadata`,
 			method: 'PUT',
 			body: metadata,
 			extractJsonBody: false // The PUT metadata route returns no content (status 204)


### PR DESCRIPTION
- API requests for captions and metadata now use the respective `/resource` routes in Content Service.
- Captions and metadata are only saved if they have been modified. If only captions were modified, then only captions are saved (same for metadata).
- If a locale has captions, but the user clears all cues and saves, the captions for that locale is deleted. (Before, we saved an empty captions file.)
- Producer will now check if the current revision's `captions` array has an entry for the current locale, before requesting captions from Content Service. If the locale can't be found in the `captions` array, no API request is made and Producer displays empty captions.