### PR TITLE
fix: Fixes for loading and saving media files in Producer X

### DIFF
--- a/capture/d2l-capture-producer/d2l-capture-producer.js
+++ b/capture/d2l-capture-producer/d2l-capture-producer.js
@@ -311,10 +311,6 @@ class CaptureProducer extends RtlMixin(InternalLocalizeMixin(LitElement)) {
 	async _createNewDraftRevision() {
 		return await this.apiClient.createRevision({
 			contentId: this._content.id,
-			body: {
-				extension: this._selectedRevision.type === 'Video' ? this._selectedRevision.extension : undefined,
-				type: this._selectedRevision.type,
-			},
 			draftFromSource: this._selectedRevision.id,
 		});
 	}

--- a/capture/d2l-capture-producer/d2l-capture-producer.js
+++ b/capture/d2l-capture-producer/d2l-capture-producer.js
@@ -313,8 +313,8 @@ class CaptureProducer extends RtlMixin(InternalLocalizeMixin(LitElement)) {
 			contentId: this._content.id,
 			body: {
 				extension: this._selectedRevision.extension,
-				sourceFormat: 'hd',
-				formats: ['ld'],
+				sourceFormat: this._selectedRevision.sourceFormat,
+				formats: this._selectedRevision.formats,
 			},
 			draftFromSource: this._selectedRevision.id,
 		});

--- a/capture/d2l-capture-producer/d2l-capture-producer.js
+++ b/capture/d2l-capture-producer/d2l-capture-producer.js
@@ -312,9 +312,8 @@ class CaptureProducer extends RtlMixin(InternalLocalizeMixin(LitElement)) {
 		return await this.apiClient.createRevision({
 			contentId: this._content.id,
 			body: {
-				extension: this._selectedRevision.extension,
-				sourceFormat: this._selectedRevision.sourceFormat,
-				formats: this._selectedRevision.formats,
+				extension: this._selectedRevision.type === 'Video' ? this._selectedRevision.extension : undefined,
+				type: this._selectedRevision.type,
 			},
 			draftFromSource: this._selectedRevision.id,
 		});

--- a/capture/d2l-capture-producer/d2l-capture-producer.js
+++ b/capture/d2l-capture-producer/d2l-capture-producer.js
@@ -577,7 +577,7 @@ class CaptureProducer extends RtlMixin(InternalLocalizeMixin(LitElement)) {
 			}
 		}
 
-		this._src = (await this.apiClient.getSignedUrlForRevision({ contentId: this.contentId, revisionId: latestRevision.id})).value;
+		this._src = (await this.apiClient.getOriginalSignedUrlForRevision({ contentId: this.contentId, revisionId: latestRevision.id})).value;
 		await this._setupLanguages();
 		if (this._enableCutsAndChapters) {
 			this._loadMetadata(this._revisionsLatestToOldest[0].id);

--- a/capture/d2l-capture-producer/locales/en.js
+++ b/capture/d2l-capture-producer/locales/en.js
@@ -20,6 +20,7 @@ export const val = {
 	confirmFinish: 'Confirm Finish',
 	confirmLoadRevisionWithUnsavedChanges: 'The current revision has unsaved changes. If you load another revision, these changes will be discarded. Do you wish to proceed?',
 	confirmOverwriteFromPastRevision: 'Copying from a past revision will overwrite your unsaved changes. Do you wish to proceed?',
+	contentObjectIsCorrupted: 'This content object is corrupted and could not be loaded',
 	copyFromPastRevision: 'Copy From Past Revision',
 	currentDraft: 'Current Draft',
 	cut: 'Cut',

--- a/capture/d2l-capture-producer/src/content-service-client.js
+++ b/capture/d2l-capture-producer/src/content-service-client.js
@@ -103,12 +103,6 @@ export default class ContentServiceClient {
 		});
 	}
 
-	getSignedUrl(contentId) {
-		return this._fetch({
-			path: `/api/${this.tenantId}/content/${contentId}/signedUrl`
-		});
-	}
-
 	processRevision({
 		contentId,
 		revisionId,

--- a/capture/d2l-capture-producer/src/content-service-client.js
+++ b/capture/d2l-capture-producer/src/content-service-client.js
@@ -105,7 +105,7 @@ export default class ContentServiceClient {
 
 	getSignedUrlForRevision({ contentId, revisionId }) {
 		return this._fetch({
-			path: `/api/${this.tenantId}/content/${contentId}/revisions/${revisionId}/signedUrl`
+			path: `/api/${this.tenantId}/content/${contentId}/revisions/${revisionId}/resources/original/signed-url`
 		});
 	}
 

--- a/capture/d2l-capture-producer/src/content-service-client.js
+++ b/capture/d2l-capture-producer/src/content-service-client.js
@@ -81,6 +81,12 @@ export default class ContentServiceClient {
 		});
 	}
 
+	getOriginalSignedUrlForRevision({ contentId, revisionId }) {
+		return this._fetch({
+			path: `/api/${this.tenantId}/content/${contentId}/revisions/${revisionId}/resources/original/signed-url`
+		});
+	}
+
 	getRevision({ contentId, revisionId }) {
 		return this._fetch({
 			path: `/api/${this.tenantId}/content/${contentId}/revisions/${revisionId}`
@@ -100,12 +106,6 @@ export default class ContentServiceClient {
 	getSignedUrl(contentId) {
 		return this._fetch({
 			path: `/api/${this.tenantId}/content/${contentId}/signedUrl`
-		});
-	}
-
-	getSignedUrlForRevision({ contentId, revisionId }) {
-		return this._fetch({
-			path: `/api/${this.tenantId}/content/${contentId}/revisions/${revisionId}/resources/original/signed-url`
 		});
 	}
 


### PR DESCRIPTION
- Load and display the original revision's media file.
- When a new draft revision is created, the `formats` and `sourceFormat` of the current revision are carried over. This prevents issues such as Video Notes (which should always be low-definition) gaining a high-definition format on save.