### PR TITLE
Work around for missing statusText in response

### DIFF
--- a/capture/d2l-capture-producer/d2l-capture-producer.js
+++ b/capture/d2l-capture-producer/d2l-capture-producer.js
@@ -602,7 +602,7 @@ class CaptureProducer extends RtlMixin(InternalLocalizeMixin(LitElement)) {
 			});
 			this._captionsUrl = res.value;
 		} catch (error) {
-			if (error.message === 'Not Found') {
+			if (error.cause === 404) {
 				this._captions = [];
 				this._captionsLoading = false;
 			} else {
@@ -631,7 +631,7 @@ class CaptureProducer extends RtlMixin(InternalLocalizeMixin(LitElement)) {
 			});
 			this._metadataLoading = false;
 		} catch (error) {
-			if (error.message === 'Not Found') {
+			if (error.cause === 404) {
 				this._metadata = { chapters: [], cuts: [] };
 				this._metadataLoading = false;
 			} else {

--- a/capture/d2l-capture-producer/src/content-service-client.js
+++ b/capture/d2l-capture-producer/src/content-service-client.js
@@ -176,7 +176,7 @@ export default class ContentServiceClient {
 
 		const response = await d2lfetch.fetch(request);
 		if (!response.ok) {
-			throw new Error(response.statusText);
+			throw new Error(response.statusText, { cause: response.status });
 		}
 
 		if (extractJsonBody) {


### PR DESCRIPTION
I'm using this in local dev, because for some reason the response `statusText` value is an empty string.

That would break my local producer, causing an error message **An error occurred while loading chapters and timeline cuts**, preventing the timeline from loading, and breaking the save draft and finish buttons