### PR TITLE
fix: Disable "Finish" button if past revision is loaded with no changes

### DIFF
--- a/capture/d2l-capture-producer/d2l-capture-producer.js
+++ b/capture/d2l-capture-producer/d2l-capture-producer.js
@@ -305,6 +305,8 @@ class CaptureProducer extends RtlMixin(InternalLocalizeMixin(LitElement)) {
 		return (
 			// Disable if content is not yet loaded.
 			!this._content ||
+			// Disable if a past revision is loaded and there are no changes. (To publish a past revision, users must save a draft first, or make changes.)
+			((this._selectedRevisionIndex !== 0) && (!this._unsavedChanges)) ||
 			// Disable if the current revision is processing.
 			this._selectedRevisionIsProcessing ||
 			// Disable if the latest revision is currently selected, it is not a draft, and there are no unsaved changes.


### PR DESCRIPTION
When the user loads a past revision and hasn't made any edits yet, it might be confusing to see that they can Finish. Now, the user must save a draft or make edits in order to Finish a past revision.