### PR TITLE
fix: Prevent captions showing up empty after auto-generation finishes

### DIFF
--- a/capture/d2l-capture-producer/d2l-capture-producer.js
+++ b/capture/d2l-capture-producer/d2l-capture-producer.js
@@ -670,10 +670,7 @@ class CaptureProducer extends RtlMixin(InternalLocalizeMixin(LitElement)) {
 							updatedRevisions[revisionIndex].processingFailed = true;
 							this._revisionsLatestToOldest = updatedRevisions;
 						} else if (revisionProgress.ready) {
-							const updatedRevisions = this._revisionsLatestToOldest.slice();
-							updatedRevisions[this._selectedRevisionIndex].ready = true;
-							this._revisionsLatestToOldest = updatedRevisions;
-							this._loadSelectedRevision();
+							this._loadContentAndAllRelatedData();
 						} else {
 							this._pollUntilRevisionIsProcessed(revisionId);
 						}


### PR DESCRIPTION
Once processing is complete, we need to reload the revisions list because auto-generation adds new captions entries to the processed revision.