### PR TITLE
fix: Display Media Player's seekbar when Producer's timeline is disabled

### DIFF
--- a/capture/d2l-capture-producer/d2l-capture-producer-editor.js
+++ b/capture/d2l-capture-producer/d2l-capture-producer-editor.js
@@ -183,7 +183,7 @@ class CaptureProducerEditor extends RtlMixin(InternalLocalizeMixin(LitElement)) 
 						controls
 						crossorigin="anonymous"
 						@cuechange="${this._handleCueChange}"
-						hide-seek-bar
+						?hide-seek-bar="${this.enableCutsAndChapters}"
 						@pause="${this._pauseUpdatingVideoTime}"
 						@play="${this._startUpdatingVideoTime}"
 						@seeking="${this._updateVideoTime}"


### PR DESCRIPTION
This is to ensure that the user still has a way to seek through the file when cuts and chapters are disabled. (e.g. for Audio files)