### PR TITLE
fix: Fall back to adjusted captions when unadjusted doesn't exist (US133334)

### DIFF
--- a/capture/d2l-capture-producer/d2l-capture-producer.js
+++ b/capture/d2l-capture-producer/d2l-capture-producer.js
@@ -540,7 +540,8 @@ class CaptureProducer extends RtlMixin(InternalLocalizeMixin(LitElement)) {
 	}
 
 	async _loadCaptions(revision, locale) {
-		if (!revision?.captions?.find(captionsEntry => captionsEntry.locale.toLowerCase() === locale.toLowerCase())) {
+		const revisionCaptionLocale = revision?.captions?.find(captionsEntry => captionsEntry.locale.toLowerCase() === locale.toLowerCase());
+		if (!revisionCaptionLocale) {
 			this._captions = [];
 			this._captionsUrl = '';
 			this._captionsLoading = false;
@@ -555,6 +556,7 @@ class CaptureProducer extends RtlMixin(InternalLocalizeMixin(LitElement)) {
 				revisionId: revision.id,
 				locale,
 				draft: true,
+				adjusted: !revisionCaptionLocale.unadjustedHash,
 			});
 			this._captionsUrl = res.value;
 		} catch (error) {


### PR DESCRIPTION
When a revision has adjusted captions, and those captions haven't been edited yet, Producer should load and display the adjusted captions. (But Producer will always save to unadjusted.)