### PR TITLE
US133334: Update Producer to handle changes to unadjusted captions API

### DIFF
--- a/capture/d2l-capture-producer/d2l-capture-producer.js
+++ b/capture/d2l-capture-producer/d2l-capture-producer.js
@@ -555,6 +555,7 @@ class CaptureProducer extends RtlMixin(InternalLocalizeMixin(LitElement)) {
 				revisionId: revision.id,
 				locale,
 				draft: true,
+				adjusted: false,
 			});
 			this._captionsUrl = res.value;
 		} catch (error) {
@@ -821,6 +822,7 @@ class CaptureProducer extends RtlMixin(InternalLocalizeMixin(LitElement)) {
 				captionsVttText: convertVttCueArrayToVttText(this._captions),
 				revisionId: revision.id,
 				locale: this._selectedLanguage.code,
+				adjusted: false,
 			});
 		} else {
 			await this.apiClient.deleteCaptions({

--- a/capture/d2l-capture-producer/d2l-capture-producer.js
+++ b/capture/d2l-capture-producer/d2l-capture-producer.js
@@ -540,8 +540,7 @@ class CaptureProducer extends RtlMixin(InternalLocalizeMixin(LitElement)) {
 	}
 
 	async _loadCaptions(revision, locale) {
-		const revisionCaptionLocale = revision?.captions?.find(captionsEntry => captionsEntry.locale.toLowerCase() === locale.toLowerCase());
-		if (!revisionCaptionLocale) {
+		if (!revision?.captions?.find(captionsEntry => captionsEntry.locale.toLowerCase() === locale.toLowerCase())) {
 			this._captions = [];
 			this._captionsUrl = '';
 			this._captionsLoading = false;
@@ -556,7 +555,6 @@ class CaptureProducer extends RtlMixin(InternalLocalizeMixin(LitElement)) {
 				revisionId: revision.id,
 				locale,
 				draft: true,
-				adjusted: !revisionCaptionLocale.unadjustedHash,
 			});
 			this._captionsUrl = res.value;
 		} catch (error) {

--- a/capture/d2l-capture-producer/src/content-service-client.js
+++ b/capture/d2l-capture-producer/src/content-service-client.js
@@ -50,7 +50,7 @@ export default class ContentServiceClient {
 		return `Content Service Client: ${this.endpoint}`;
 	}
 
-	async getCaptionsUrl({ contentId, revisionId, locale, adjusted = false }) {
+	async getCaptionsUrl({ contentId, revisionId, locale, adjusted = true }) {
 		const headers = new Headers();
 		headers.append('pragma', 'no-cache');
 		headers.append('cache-control', 'no-cache');
@@ -116,7 +116,7 @@ export default class ContentServiceClient {
 		});
 	}
 
-	updateCaptions({ contentId, revisionId, locale, captionsVttText, adjusted = false }) {
+	updateCaptions({ contentId, revisionId, locale, captionsVttText, adjusted = true }) {
 		return this._fetch({
 			path: `/api/${this.tenantId}/content/${contentId}/revisions/${revisionId}/resources/captions`,
 			method: 'PUT',

--- a/capture/d2l-capture-producer/src/content-service-client.js
+++ b/capture/d2l-capture-producer/src/content-service-client.js
@@ -24,11 +24,11 @@ export default class ContentServiceClient {
 		});
 	}
 
-	deleteCaptions({ contentId, revisionId, locale, adjusted = false }) {
+	deleteCaptions({ contentId, revisionId, locale }) {
 		return this._fetch({
 			path: `/api/${this.tenantId}/content/${contentId}/revisions/${revisionId}/resources/captions`,
 			method: 'DELETE',
-			query: { locale, adjusted },
+			query: { locale },
 		});
 	}
 


### PR DESCRIPTION
- Falling back to adjusted captions is now handled on the Content Service backend. So this PR reverts #103.
- The DELETE captions route no longer takes an "adjusted" parameter, so Producer's calls to that route have been modified accordingly.

The Content Service changes can be found in https://github.com/Brightspace/d2l-content-service/pull/1745.