### PR TITLE
Recover from URL expiry; add support for new media-player mediaType attribute

### DIFF
--- a/capture/d2l-capture-producer/d2l-capture-producer-editor.js
+++ b/capture/d2l-capture-producer/d2l-capture-producer-editor.js
@@ -32,6 +32,7 @@ class CaptureProducerEditor extends RtlMixin(InternalLocalizeMixin(LitElement)) 
 			defaultLanguage: { type: Object },
 			enableCutsAndChapters: { type: Boolean },
 			languages: { type: Array },
+			mediaType: { type: String },
 			metadata: { type: Object },
 			metadataLoading: { type: Boolean, attribute: 'metadata-loading' },
 			selectedLanguage: { type: Object },
@@ -183,7 +184,9 @@ class CaptureProducerEditor extends RtlMixin(InternalLocalizeMixin(LitElement)) 
 						controls
 						crossorigin="anonymous"
 						@cuechange="${this._handleCueChange}"
+						@error="${this._handleMediaError}"
 						?hide-seek-bar="${this.enableCutsAndChapters}"
+						media-type="${this.mediaType}"
 						@pause="${this._pauseUpdatingVideoTime}"
 						@play="${this._startUpdatingVideoTime}"
 						@seeking="${this._updateVideoTime}"
@@ -904,6 +907,10 @@ class CaptureProducerEditor extends RtlMixin(InternalLocalizeMixin(LitElement)) 
 
 	_handleCueChange() {
 		this._activeCue = this._mediaPlayer.activeCue;
+	}
+
+	_handleMediaError() {
+		this.dispatchEvent(new CustomEvent('media-error', { composed: false }));
 	}
 
 	_handleMediaPlayerTimeJumped(event) {

--- a/capture/d2l-capture-producer/d2l-capture-producer.js
+++ b/capture/d2l-capture-producer/d2l-capture-producer.js
@@ -152,8 +152,8 @@ class CaptureProducer extends RtlMixin(InternalLocalizeMixin(LitElement)) {
 		this._selectedLanguage = null;
 		this._languageToLoad = {};
 		this._mediaLoaded = false;
-		this._mediaType = null;
-		this._attemptedReloadOnError  = false;
+		this._mediaType = '';
+		this._attemptedReloadOnError = false;
 	}
 
 	async connectedCallback() {

--- a/capture/d2l-capture-producer/d2l-capture-producer.js
+++ b/capture/d2l-capture-producer/d2l-capture-producer.js
@@ -476,6 +476,8 @@ class CaptureProducer extends RtlMixin(InternalLocalizeMixin(LitElement)) {
 	}
 
 	async _handleMediaLoaded() {
+		this._attemptedReloadOnError = false;
+
 		// The Media Player uses its <video> element to parse the captions data.
 		// Because of that, when a revision is loaded, we load captions in this event handler,
 		// which is only invoked once the editor has rendered and its Media Player is finished loading.

--- a/core/d2l-content-uploader/src/components/preview.js
+++ b/core/d2l-content-uploader/src/components/preview.js
@@ -142,7 +142,7 @@ export class Preview extends MobxReactionUpdate(RequesterMixin(InternalLocalizeM
 		}
 
 		return html`
-			<d2l-labs-media-player style="width:100%">
+			<d2l-labs-media-player style="width:100%" media-type="${this._isAudio() ? 'audio' : 'video'}">
 				${this._mediaSources.map(mediaSource => this._renderSource(mediaSource))}
 			</d2l-labs-media-player>`;
 	}

--- a/core/d2l-content-viewer/d2l-content-viewer.js
+++ b/core/d2l-content-viewer/d2l-content-viewer.js
@@ -81,6 +81,7 @@ class ContentViewer extends LitElement {
 		return this._mediaSources && this._mediaSources.length > 0 && html`
 			<d2l-labs-media-player
 				crossorigin="anonymous"
+				media-type="${this._revision.type === ContentType.Video ? 'video' : 'audio'}"
 				@error=${this._onError}
 				@trackloadfailed=${this._onTrackLoadFailed}
 				@tracksmenuitemchanged=${this._onTracksChanged}

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@adobe/lit-mobx": "0.0.4",
     "@brightspace-ui-labs/accordion": "^2",
     "@brightspace-ui-labs/file-uploader": "^2",
-    "@brightspace-ui-labs/media-player": "^1",
+    "@brightspace-ui-labs/media-player": "^2",
     "@brightspace-ui-labs/pagination": "^1",
     "@brightspace-ui-labs/video-producer": "^0",
     "@brightspace-ui/core": "^1",


### PR DESCRIPTION
I'll update the PR with the new media-player version once https://github.com/BrightspaceUILabs/media-player/pull/118 is merged. I'm going to bump the major version there.