### PR TITLE
restart upload on network error and fix localize issue

### DIFF
--- a/core/d2l-content-uploader/src/components/main.js
+++ b/core/d2l-content-uploader/src/components/main.js
@@ -2,6 +2,7 @@ import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
 import ContentServiceClient from '../util/content-service-client';
 import UserBrightspaceClient from '../util/user-brightspace-client.js';
+import { InternalLocalizeMixin } from '../mixins/internal-localize-mixin.js';
 import { ProviderMixin } from '@brightspace-ui/core/mixins/provider-mixin.js';
 import { MobxReactionUpdate } from '@adobe/lit-mobx';
 import { Uploader } from '../state/uploader';
@@ -18,7 +19,7 @@ const VIEW = Object.freeze({
 	LOADING: 'LOADING'
 });
 
-export class Main extends MobxReactionUpdate(ProviderMixin(LitElement)) {
+export class Main extends InternalLocalizeMixin(MobxReactionUpdate(ProviderMixin(LitElement))) {
 	static get properties() {
 		return {
 			apiEndpoint: { type: String, attribute: 'api-endpoint' },


### PR DESCRIPTION
- retrying the upload to s3 when a network error occurs
- added `InternalLocalizeMixin` to fix issue where uploader hangs on the progress view after an error, should now go back to upload view with the localized error message