### PR TITLE
fix: Prevent window from scrolling during captions auto-scroll

### DIFF
--- a/capture/d2l-capture-producer/src/d2l-video-producer-captions.js
+++ b/capture/d2l-capture-producer/src/d2l-video-producer-captions.js
@@ -695,7 +695,7 @@ class VideoProducerCaptions extends InternalLocalizeMixin(LitElement) {
 		}
 
 		if (activeCueListItem) {
-			activeCueListItem.scrollIntoView();
+			activeCueListItem.scrollIntoView({block: 'nearest', inline: 'nearest'});
 		}
 	}
 


### PR DESCRIPTION
The window scroll was causing the "Advanced Editing" dialog to become cut-off in Safari. More details: https://trello.com/c/6aahlajV

Solution from: https://stackoverflow.com/a/67433987. Verified this fix in Safari, Firefox, Chrome, Edge.

Safari recording:

https://user-images.githubusercontent.com/9592685/144883909-b1a84e72-368f-48cb-b6b8-dc50decbdbb6.mp4
