### PR TITLE
Fix dialog size

### DIFF
--- a/capture/d2l-capture-producer/d2l-capture-producer-editor.js
+++ b/capture/d2l-capture-producer/d2l-capture-producer-editor.js
@@ -82,6 +82,7 @@ class CaptureProducerEditor extends RtlMixin(InternalLocalizeMixin(LitElement)) 
 				margin-top: 8px;
 				vertical-align: top;
 				width: 170px;
+				min-width: 170px;
 			}
 
 			.d2l-video-producer-timeline-mode-button input[type="radio"] {

--- a/core/d2l-content-uploader/src/components/preview.js
+++ b/core/d2l-content-uploader/src/components/preview.js
@@ -119,20 +119,32 @@ export class Preview extends MobxReactionUpdate(RequesterMixin(InternalLocalizeM
 
 	async _onAdvancedEditing() {
 		const location = `/d2l/le/contentservice/producer/${this._contentId}/view`;
+		let dialog = null;
+		let topWindow = null;
+
+		const onResize = () => {
+			dialog.style.width = 'calc(100% - 50px)';
+			dialog.style.maxWidth = '1200px';
+			dialog.style.left = `${(topWindow.innerWidth - dialog.offsetWidth) / 2}px`;
+			dialog.style.top = `calc(${topWindow.scrollY}px + 25px)`;
+			dialog.style.height = 'calc(100% - 50px)';
+		};
+
 		await D2L.LP.Web.UI.Desktop.MasterPages.Dialog.Open(
 			getComposedActiveElement(),
 			new D2L.LP.Web.Http.UrlLocation(location),
 			{
 				Onload: (handle) => {
 					setTimeout(() => {
-						handle.dialog.style.width = 'calc(100% - 50px)';
-						handle.dialog.style.left = '25px';
-						handle.dialog.style.top = `calc(${handle.win.top.scrollY}px + 25px)`;
-						handle.dialog.style.height = 'calc(100% - 50px)';
+						dialog = handle.dialog;
+						topWindow = handle.win.top;
+						onResize();
+						topWindow.addEventListener('resize', onResize);
 					}, 500);
 				}
 			}
 		);
+		topWindow.removeEventListener('resize', onResize);
 	}
 
 	_onChangeFile() {

--- a/core/d2l-content-uploader/src/components/preview.js
+++ b/core/d2l-content-uploader/src/components/preview.js
@@ -130,7 +130,7 @@ export class Preview extends MobxReactionUpdate(RequesterMixin(InternalLocalizeM
 			dialog.style.height = 'calc(100% - 50px)';
 		};
 
-		await D2L.LP.Web.UI.Desktop.MasterPages.Dialog.Open(
+		const dialogResult = await D2L.LP.Web.UI.Desktop.MasterPages.Dialog.Open(
 			getComposedActiveElement(),
 			new D2L.LP.Web.Http.UrlLocation(location),
 			{
@@ -144,7 +144,10 @@ export class Preview extends MobxReactionUpdate(RequesterMixin(InternalLocalizeM
 				}
 			}
 		);
-		topWindow.removeEventListener('resize', onResize);
+
+		dialogResult.AddListener(() => {
+			topWindow.removeEventListener('resize', onResize);
+		});
 	}
 
 	_onChangeFile() {


### PR DESCRIPTION
Max dialog size is set to 1200px
If the window was resized - reset dialog location
min-width: 170px is required to fix broken button styles in Firefox