### PR TITLE
fix: Do not make Media Player jump to cue start when cue time is edited

### DIFF
--- a/capture/d2l-capture-producer/d2l-capture-producer-editor.js
+++ b/capture/d2l-capture-producer/d2l-capture-producer-editor.js
@@ -902,13 +902,16 @@ class CaptureProducerEditor extends RtlMixin(InternalLocalizeMixin(LitElement)) 
 			editedCue.startTime = Math.max(editedCue.endTime - cueDuration, 0);
 		}
 
+		// Make the end time slightly later than the Media Player's current time position.
+		// If this is not done, Producer's Media Player will not update to display the cue. (Because the "end time" specifies when to *hide* the cue.)
+		// This would be confusing to users, due to the lack of visual feedback.
+		if (editedCue.endTime < this._mediaPlayer.duration) {
+			editedCue.endTime += 0.001;
+		}
+
 		this._mediaPlayer.textTracks[0].addCue(editedCue); // TextTrack.addCue() automatically inserts the cue at the appropriate index based on startTime.
 		this._mediaPlayer.textTracks[0].removeCue(originalCue);
 		this._syncCaptionsWithMediaPlayer();
-
-		setTimeout(() => {
-			this._mediaPlayer.currentTime = editedCue.startTime + 0.001;
-		}, 100); // Give the new cue element time to be drawn.
 	}
 
 	_handleCaptionsCueStartTimestampSynced(event) {
@@ -923,10 +926,6 @@ class CaptureProducerEditor extends RtlMixin(InternalLocalizeMixin(LitElement)) 
 		this._mediaPlayer.textTracks[0].addCue(editedCue); // TextTrack.addCue() automatically inserts the cue at the appropriate index based on startTime.
 		this._mediaPlayer.textTracks[0].removeCue(originalCue);
 		this._syncCaptionsWithMediaPlayer();
-
-		setTimeout(() => {
-			this._mediaPlayer.currentTime = editedCue.startTime + 0.001;
-		}, 100); // Give the new cue element time to be drawn.
 	}
 
 	_handleCaptionsVttReplaced(e) {


### PR DESCRIPTION
Previously, Producer's Media Player would jump to the start time of a cue whenever that cue's start or end time was edited.

However, this jumping caused some functional glitches. Additionally, we decided that this behaviour would be confusing for most users.

Before:

https://user-images.githubusercontent.com/9592685/145086637-255de74c-8075-4432-95fc-4650ae424c05.mp4

After:

https://user-images.githubusercontent.com/9592685/145086663-1860dae1-3190-43fb-b9cd-b5709b3464ff.mp4
