### PR TITLE
Do not slice srclang

### DIFF
--- a/core/d2l-content-viewer/d2l-content-viewer.js
+++ b/core/d2l-content-viewer/d2l-content-viewer.js
@@ -235,7 +235,7 @@ class ContentViewer extends InternalLocalizeMixin(LitElement) {
 	}
 
 	_renderCaptionsTrack(captionsUrl) {
-		return html`<track src="${captionsUrl.Value}" kind="captions" label=${captionsUrl.Locale} srclang=${captionsUrl.Locale.slice(0, 2)}>`;
+		return html`<track src="${captionsUrl.Value}" kind="captions" label=${captionsUrl.Locale} srclang=${captionsUrl.Locale}>`;
 	}
 
 	_renderMediaSource(source) {


### PR DESCRIPTION
fix for https://trello.com/c/zHhjjNxh/259-media-player-if-a-video-has-multiple-captions-in-english-eg-us-uk-canada-only-one-can-be-displayed