### PR TITLE
fix: Prevent cue end time from going past file duration when syncing cue start time

### DIFF
--- a/capture/d2l-capture-producer/d2l-capture-producer-editor.js
+++ b/capture/d2l-capture-producer/d2l-capture-producer-editor.js
@@ -936,7 +936,7 @@ class CaptureProducerEditor extends RtlMixin(InternalLocalizeMixin(LitElement)) 
 		const editedCue = new VTTCue(originalCue.startTime, originalCue.endTime, originalCue.text);
 		editedCue.startTime = Math.floor(this._mediaPlayer.currentTime * 1000) / 1000; // WebVTT uses 3-decimal precision.
 		if (editedCue.startTime >= editedCue.endTime) {
-			editedCue.endTime = editedCue.startTime + cueDuration;
+			editedCue.endTime = Math.min(editedCue.startTime + cueDuration, this._mediaPlayer.duration);
 		}
 
 		this._mediaPlayer.textTracks[0].addCue(editedCue); // TextTrack.addCue() automatically inserts the cue at the appropriate index based on startTime.


### PR DESCRIPTION
When a cue's "Sync start time" button is clicked, and the Media Player's current time position is **later** than the cue's end time, the cue's end time is automatically updated using this formula:
```
    newEndTime = newStartTime + (oldEndTime - oldStartTime)
```
to ensure that the cue's duration stays the same.

However, this can cause the new end time to go past the audio/video file's duration.

The fix is to set end time to the file duration, if the calculated end time would have gone past it.