### PR TITLE
Use extensions instead of CS supported mime types to determine which video/audio files can be uploaded

### DIFF
--- a/core/d2l-content-uploader/src/util/content-service-client.js
+++ b/core/d2l-content-uploader/src/util/content-service-client.js
@@ -56,10 +56,6 @@ export default class ContentServiceClient {
 		});
 	}
 
-	getSupportedMimeTypes() {
-		return this._fetch({ path: '/api/conf/supported-mime-types' });
-	}
-
 	getWorkflowProgress({
 		contentId,
 		revisionId


### PR DESCRIPTION
I found that you can use extensions instead of mime types, so I think that's a better option since mime types are inconsistent between browsers. I tested in Chrome, Safari, and Firefox in local dev.