### PR TITLE
Don't use cache for call to get media url

### DIFF
--- a/core/d2l-content-viewer/src/clients/rest-client.js
+++ b/core/d2l-content-viewer/src/clients/rest-client.js
@@ -28,8 +28,7 @@ export default class ContentServiceClient {
 			query: {
 				format: format ? format.value : undefined,
 				attachment
-			},
-			doNotUseCache: false
+			}
 		});
 		return {
 			expires: result.ExpireTime * 1000,


### PR DESCRIPTION
I'm not really sure if this is causing issues, but it could explain some weird stuff I've seen. Either way, it seems very wrong to cache the response for getting the signed URL