### PR TITLE
Producer - Never cache on GET requests

### DIFF
--- a/capture/d2l-capture-producer/src/content-service-client.js
+++ b/capture/d2l-capture-producer/src/content-service-client.js
@@ -51,33 +51,21 @@ export default class ContentServiceClient {
 	}
 
 	async getCaptionsUrl({ contentId, revisionId, locale, adjusted = true }) {
-		const headers = new Headers();
-		headers.append('pragma', 'no-cache');
-		headers.append('cache-control', 'no-cache');
 		return await this._fetch({
 			path: `/api/${this.tenantId}/content/${contentId}/revisions/${revisionId}/resources/captions/signed-url`,
-			query: { locale, exact: true, adjusted },
-			headers
+			query: { locale, exact: true, adjusted }
 		});
 	}
 
 	getContent(id) {
-		const headers = new Headers();
-		headers.append('pragma', 'no-cache');
-		headers.append('cache-control', 'no-cache');
 		return this._fetch({
-			path: `/api/${this.tenantId}/content/${id}`,
-			headers,
+			path: `/api/${this.tenantId}/content/${id}`
 		});
 	}
 
 	getMetadata({ contentId, revisionId }) {
-		const headers = new Headers();
-		headers.append('pragma', 'no-cache');
-		headers.append('cache-control', 'no-cache');
 		return this._fetch({
-			path: `/api/${this.tenantId}/content/${contentId}/revisions/${revisionId}/resources/metadata/file-content`,
-			headers
+			path: `/api/${this.tenantId}/content/${contentId}/revisions/${revisionId}/resources/metadata/file-content`
 		});
 	}
 
@@ -94,12 +82,8 @@ export default class ContentServiceClient {
 	}
 
 	getRevisionProgress({ contentId, revisionId }) {
-		const headers = new Headers();
-		headers.append('pragma', 'no-cache');
-		headers.append('cache-control', 'no-cache');
 		return this._fetch({
-			path: `/api/${this.tenantId}/content/${contentId}/revisions/${revisionId}/progress`,
-			headers
+			path: `/api/${this.tenantId}/content/${contentId}/revisions/${revisionId}/progress`
 		});
 	}
 
@@ -163,6 +147,11 @@ export default class ContentServiceClient {
 	}) {
 		if (body && contentType) {
 			headers.append('Content-Type', contentType);
+		}
+
+		if (method === 'GET') {
+			headers.append('pragma', 'no-cache');
+			headers.append('cache-control', 'no-cache');
 		}
 
 		const requestInit = {


### PR DESCRIPTION
Caching with GetOriginalSignedUrlForRevision was causing an issue with URL expiry, but I figure I should just make it so that all GET requests in Producer don't cache by default. If there's a GET call in the future we should cache for, we can add a new parameter to _fetch to support that.