### PR TITLE
Producer: ask before exit if there are unsaved changes

### DIFF
--- a/capture/d2l-capture-producer/d2l-capture-producer.js
+++ b/capture/d2l-capture-producer/d2l-capture-producer.js
@@ -169,6 +169,8 @@ class CaptureProducer extends RtlMixin(InternalLocalizeMixin(LitElement)) {
 			await this._setupLanguages();
 			await this._loadContentAndAllRelatedData();
 		});
+
+		window.addEventListener('beforeunload', this._askBeforeExit.bind(this));
 	}
 
 	render() {
@@ -292,6 +294,16 @@ class CaptureProducer extends RtlMixin(InternalLocalizeMixin(LitElement)) {
 				</d2l-dialog-confirm>
 			</div>
 		`;
+	}
+
+	_askBeforeExit(e) {
+		// Ref: https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onbeforeunload
+		if (this._saveIsDisabled) {
+			delete e.returnValue;
+		} else {
+			e.preventDefault();
+			e.returnValue = '';
+		}
 	}
 
 	async _createNewDraftRevision() {


### PR DESCRIPTION
Want to keep the changes minimal. This is to support https://trello.com/c/G6xrWO0F/273-producer-x-you-can-close-the-producer-and-lose-your-changes-without-getting-any-warning (Peter's request)

When there are no changes, the user can close the tab or leave the page __without__ a prompt.
![Screen Shot 2021-12-13 at 9 08 01 AM](https://user-images.githubusercontent.com/22655/145827093-9f1573c1-2f90-4634-8afe-69edc3d41dc3.png)

When there are changes this browser native dialog will appear:
![Screen Shot 2021-12-13 at 9 09 09 AM](https://user-images.githubusercontent.com/22655/145827364-65c2753e-5987-4a4d-b853-c56a5f3d654a.png)

Clicking "Cancel" will do nothing, and the user can manually save. Clicking "Leave" will force the page to unload and unsaved changes are lost.

Peter wanted the dialog to auto save, but that would have been more complicated and possibly introduce bugs.