### PR TITLE
Removed on-track-changed listener

### DIFF
--- a/core/d2l-content-viewer/d2l-content-viewer.js
+++ b/core/d2l-content-viewer/d2l-content-viewer.js
@@ -46,7 +46,6 @@ class ContentViewer extends InternalLocalizeMixin(LitElement) {
 		super();
 		this._resourceEntity = null;
 		this._captionSignedUrls = [];
-		this._captionsSignedUrlStartTime = null;
 		this._lastTrackLoadFailedTime = null;
 		this._trackErrorFetchTimeoutId = null;
 		this._revision = null;
@@ -91,7 +90,6 @@ class ContentViewer extends InternalLocalizeMixin(LitElement) {
 				@error=${this._onError}
 				@loadeddata=${this._onLoadedData}
 				@trackloadfailed=${this._onTrackLoadFailed}
-				@tracksmenuitemchanged=${this._onTracksChanged}
 				?allow-download-on-error=${this.allowDownloadOnError}>
 				${this._mediaSources.map(mediaSource => this._renderMediaSource(mediaSource))}
 				${this._captionSignedUrls.map(captionSignedUrl => this._renderCaptionsTrack(captionSignedUrl))}
@@ -146,8 +144,6 @@ class ContentViewer extends InternalLocalizeMixin(LitElement) {
 			await this.updateComplete;
 
 			this._captionSignedUrls = captionSignedUrls;
-			this._captionsSignedUrlStartTime = (new Date()).getTime();
-			this._captionsSignedUrlExpireTime = ((this._captionSignedUrls.length && this._captionSignedUrls[0].ExpireTime) || 0) * 1000;
 			this.requestUpdate();
 		}
 	}
@@ -230,12 +226,6 @@ class ContentViewer extends InternalLocalizeMixin(LitElement) {
 		if (shouldWaitToLoadCaptions) {
 			this._trackErrorFetchTimeoutId = setTimeout(this._loadCaptions.bind(this), TRACK_ERROR_FETCH_WAIT_MILLISECONDS);
 		} else {
-			await this._loadCaptions();
-		}
-	}
-
-	async _onTracksChanged() {
-		if (Date.now() > this._captionsSignedUrlExpireTime) {
 			await this._loadCaptions();
 		}
 	}


### PR DESCRIPTION
We do not need it, since if the track urls not expired - it will load fine and if expired - it will be handled by onTrackLoadFailed