### PR TITLE
Use source node instead of src attribute

### DIFF
--- a/capture/d2l-capture-producer/d2l-capture-producer-editor.js
+++ b/capture/d2l-capture-producer/d2l-capture-producer-editor.js
@@ -33,6 +33,7 @@ class CaptureProducerEditor extends RtlMixin(InternalLocalizeMixin(LitElement)) 
 			captionsUrl: { type: String },
 			defaultLanguage: { type: Object },
 			enableCutsAndChapters: { type: Boolean },
+			format: { type: String },
 			languages: { type: Array },
 			mediaType: { type: String },
 			metadata: { type: Object },
@@ -169,6 +170,7 @@ class CaptureProducerEditor extends RtlMixin(InternalLocalizeMixin(LitElement)) 
 		this.metadata = { cuts: [], chapters: [] };
 		this.metadataLoading = false;
 		this.timelineVisible = false;
+		this.format = '';
 		this.src = '';
 		this.languages = [];
 		this.defaultLanguage = {};
@@ -212,9 +214,9 @@ class CaptureProducerEditor extends RtlMixin(InternalLocalizeMixin(LitElement)) 
 						@pause="${this._pauseUpdatingVideoTime}"
 						@play="${this._startUpdatingVideoTime}"
 						@seeking="${this._updateVideoTime}"
-						src="${this.src}"
 						@trackloaded="${this._handleTrackLoaded}"
 					>
+						<source src="${this.src}" label="${this.format}">
 						${this.captionsUrl ? html`<track default-ignore-preferences src="${this.captionsUrl}" srclang="${this._formatCaptionsSrcLang()}" label="${this.selectedLanguage.name}" kind="subtitles">` : ''}
 					</d2l-labs-media-player>
 					<d2l-tabs>

--- a/capture/d2l-capture-producer/d2l-capture-producer.js
+++ b/capture/d2l-capture-producer/d2l-capture-producer.js
@@ -36,6 +36,7 @@ class CaptureProducer extends RtlMixin(InternalLocalizeMixin(LitElement)) {
 			_defaultLanguage: { type: Object, attribute: false },
 			_errorOccurred: { type: Boolean, attribute: false },
 			_finishing: { type: Boolean, attribute: false },
+			_format: { type: String, attribute: false },
 			_languages: { type: Array, attribute: false },
 			_languageToLoad: { type: Object, attribute: false },
 			_mediaType: { type: String, attribute: false },
@@ -146,6 +147,7 @@ class CaptureProducer extends RtlMixin(InternalLocalizeMixin(LitElement)) {
 		this._metadata = { cuts: [], chapters: [] };
 		this._metadataChanged = false;
 		this._metadataLoading = true;
+		this._format = '';
 		this._src = '';
 		this._defaultLanguage = {};
 		this._languages = null;
@@ -196,6 +198,7 @@ class CaptureProducer extends RtlMixin(InternalLocalizeMixin(LitElement)) {
 					@captions-url-changed="${this._handleCaptionsUrlChanged}"
 					?enableCutsAndChapters="${this._enableCutsAndChapters}"
 					.defaultLanguage="${this._defaultLanguage}"
+					.format="${this._format}"
 					.languages="${this._languages}"
 					@media-error="${this._handleMediaError}"
 					@media-loaded="${this._handleMediaLoaded}"
@@ -612,6 +615,8 @@ class CaptureProducer extends RtlMixin(InternalLocalizeMixin(LitElement)) {
 			contentId: this.contentId,
 			revisionId: this._selectedRevision.id,
 		});
+		const formatsBestFirst = ['hd', 'sd', 'ld', 'mp3'];
+		this._format = formatsBestFirst.find(f => this._selectedRevision.formats?.includes(f));
 		this._src = signedUrlResponse.value;
 	}
 
@@ -671,6 +676,7 @@ class CaptureProducer extends RtlMixin(InternalLocalizeMixin(LitElement)) {
 		this._captionsUrl = '';
 
 		this._src = '';
+		this._format = '';
 		this._mediaType = this._getMediaType();
 		await this._loadMedia();
 


### PR DESCRIPTION
Attempt to fix Firefox issue with broken preview: https://trello.com/c/TnBQ51mi/324-producer-x-video-preview-stops-working-after-creating-a-draft-revision-and-then-swapping-between-revisions