### PR TITLE
fix: Limit the text of individual captions cues to 100 characters

### DIFF
--- a/capture/d2l-capture-producer/src/constants.js
+++ b/capture/d2l-capture-producer/src/constants.js
@@ -22,6 +22,7 @@ const constants = {
 	// Captions
 	ADD_NEW_CUE_KEY_CODE: 13, // 13 is the "Enter" key in Javascript
 	MAX_CAPTIONS_UPLOAD_SIZE_IN_BYTES: 15 * 1024 * 1024, // 15MB
+	MAX_CAPTIONS_CUE_CHARACTERS: 100, // Auto-generated captions: 40 character per line limit, 2 lines per caption cue limit = 80 characters. We add a 20 character buffer.
 	NEW_CUE_DEFAULT_DURATION_IN_SECONDS: 3,
 	NUM_OF_VISIBLE_CUES: 60, // https://web.dev/dom-size/
 

--- a/capture/d2l-capture-producer/src/d2l-video-producer-captions.js
+++ b/capture/d2l-capture-producer/src/d2l-video-producer-captions.js
@@ -223,10 +223,11 @@ class CaptionsCueListItem extends InternalLocalizeMixin(LitElement) {
 		return html`
 			<div class="d2l-video-producer-captions-cue-main-controls">
 				<textarea
+					aria-label=${this.localize('captionsCueText')}
 					class="d2l-input d2l-video-producer-captions-cue-text-input"
 					@focus="${this._handleFocus}"
 					@input="${this._handleTextInput}"
-					aria-label=${this.localize('captionsCueText')}
+					maxlength="${constants.MAX_CAPTIONS_CUE_CHARACTERS}"
 					rows="2"
 				>${this.cue.text}</textarea>
 				<div class="d2l-video-producer-captions-cue-main-controls-buttons">


### PR DESCRIPTION
If a cue's text is too long, Saving and Finishing will fail.

Captions auto-generation should produce, at most, 80 characters per cue. As such, 100 characters should be a safe upper limit.

I've verified locally that Save and Finish work when there are several cues with 100 characters.