### PR TITLE
fix: Attempt to fix Firefox revisions bug by seeking to start on load

### DIFF
--- a/capture/d2l-capture-producer/d2l-capture-producer-editor.js
+++ b/capture/d2l-capture-producer/d2l-capture-producer-editor.js
@@ -198,6 +198,7 @@ class CaptureProducerEditor extends RtlMixin(InternalLocalizeMixin(LitElement)) 
 				this._changeToSeekMode();
 			}
 			this._videoLoaded = true;
+			this._mediaPlayer.currentTime = 0; // Seek so that the signed URL request is forced to finish on Firefox. Details: https://trello.com/c/TnBQ51mi
 			this.dispatchEvent(new CustomEvent('media-loaded', { composed: false }));
 		});
 	}


### PR DESCRIPTION
Couldn't verify that this fixes the issue on local.

However, I verified that setting `currentTime = 0` always forces the Media Player to do a seek operation, even if the Media Player is already at 00:00:00. So the seeking should work.