### PR TITLE
Make out parameter in cuts nullable

### DIFF
--- a/capture/d2l-capture-producer/src/timeline.js
+++ b/capture/d2l-capture-producer/src/timeline.js
@@ -544,7 +544,7 @@ class Timeline {
 				}
 			}
 
-			if (cut.out < this.durationSeconds) {
+			if (cut.out && cut.out < this.durationSeconds) {
 				const markAtEndOfCut = this._getCutEndingAtTime(cut.out);
 
 				if (!markAtEndOfCut) {


### PR DESCRIPTION
https://trello.com/c/0e3Pez5r/245-content-video-make-cuts-in-and-out-timestamps-nullable-in-the-lms-model-class
Also see  [#17238](https://github.com/Brightspace/lms/pull/17238)