### PR TITLE
fix: Prevent tooltips from going off-position when window is small

### DIFF
--- a/capture/d2l-capture-producer/d2l-capture-producer-editor.js
+++ b/capture/d2l-capture-producer/d2l-capture-producer-editor.js
@@ -81,6 +81,7 @@ class CaptureProducerEditor extends RtlMixin(InternalLocalizeMixin(LitElement)) 
 				height: 90px;
 				justify-content: center;
 				margin-top: 8px;
+				position: relative;
 				vertical-align: top;
 				width: 160px;
 				min-width: 160px;


### PR DESCRIPTION
In order for the tooltips' positions to anchor correctly, one of their ancestor elements needed to have an explicitly-defined "position" attribute.