### PR TITLE
Move methods for reusability

### DIFF
--- a/applications/d2l-capture-central/src/components/capture-central-list.js
+++ b/applications/d2l-capture-central/src/components/capture-central-list.js
@@ -156,8 +156,8 @@ export class CaptureCentralList extends DependencyRequester(InternalLocalizeMixi
 		this.loading = true;
 		const { sortQuery, searchQuery, dateModified, dateCreated } = this.queryParams;
 
-		const func = this.page === '/recycle-bin' ? this._handleDeletedVideoSearch : this._handleVideoSearch();
-		func({
+		const searchFunc = this.page === '/recycle-bin' ? this._handleDeletedVideoSearch : this._handleVideoSearch;
+		searchFunc({
 			append,
 			createdAt: dateCreated,
 			query: searchQuery,

--- a/applications/d2l-capture-central/src/components/capture-central-list.js
+++ b/applications/d2l-capture-central/src/components/capture-central-list.js
@@ -17,7 +17,6 @@ import { InternalLocalizeMixin } from '../mixins/internal-localize-mixin.js';
 import { NavigationMixin } from '../mixins/navigation-mixin.js';
 import { navigationSharedStyle } from '../style/d2l-navigation-shared-styles.js';
 import { rootStore } from '../state/root-store.js';
-import { root } from '@polymer/polymer/lib/utils/path';
 
 export class CaptureCentralList extends DependencyRequester(InternalLocalizeMixin(NavigationMixin(contentSearchMixin(LitElement)))) {
 	static get properties() {

--- a/applications/d2l-capture-central/src/components/capture-central-list.js
+++ b/applications/d2l-capture-central/src/components/capture-central-list.js
@@ -22,7 +22,7 @@ export class CaptureCentralList extends DependencyRequester(InternalLocalizeMixi
 	static get properties() {
 		return {
 			loading: { type: Boolean, attribute: false },
-			page: {type: String, attribute: ""}
+			page: {type: String, attribute: ''}
 		};
 	}
 
@@ -98,7 +98,7 @@ export class CaptureCentralList extends DependencyRequester(InternalLocalizeMixi
 	}
 
 	changeSort({ detail = {} }) {
- 		const { sortKey, sortQuery } = detail;
+		const { sortKey, sortQuery } = detail;
 		if (/^(createdAt|updatedAt)$/.test(sortKey)) {
 			this.dateField = sortKey;
 		}
@@ -106,8 +106,8 @@ export class CaptureCentralList extends DependencyRequester(InternalLocalizeMixi
 		this._navigate(this.page, {
 			...this.queryParams,
 			sortQuery
-		}); 
-		}
+		});
+	}
 
 	getCompareBasedOnSort(item) {
 		const itemUpdatedAtDate = new Date(item.updatedAt);
@@ -152,11 +152,11 @@ export class CaptureCentralList extends DependencyRequester(InternalLocalizeMixi
 		}
 	}
 
-	async loadNext({ append = true} = {}) {		
+	async loadNext({ append = true} = {}) {
 		this.loading = true;
 		const { sortQuery, searchQuery, dateModified, dateCreated } = this.queryParams;
 
-		const func = this.page == '/recycle-bin' ? this._handleDeletedVideoSearch : this._handleVideoSearch();
+		const func = this.page === '/recycle-bin' ? this._handleDeletedVideoSearch : this._handleVideoSearch();
 		func({
 			append,
 			createdAt: dateCreated,
@@ -173,7 +173,7 @@ export class CaptureCentralList extends DependencyRequester(InternalLocalizeMixi
 			rootStore.routingStore,
 			'queryParams',
 			change => {
-				if (this.loading || rootStore.routingStore.page != this.page) {
+				if (this.loading || rootStore.routingStore.page !== this.page) {
 					return;
 				}
 
@@ -198,7 +198,7 @@ export class CaptureCentralList extends DependencyRequester(InternalLocalizeMixi
 					sortQuery: updatedSortQuery,
 					dateCreated: updatedDateCreated,
 					dateModified: updatedDateModified,
-					filter: this.page == 'recycle-bin' ? "DELETED" : undefined,
+					filter: this.page === 'recycle-bin' ? 'DELETED' : undefined,
 				};
 				this.reloadPage();
 			}
@@ -216,14 +216,6 @@ export class CaptureCentralList extends DependencyRequester(InternalLocalizeMixi
 		}
 	}
 
-	renderNotFound() {
-		return !this.loading && this._videos.length === 0 ? html`
-			<div class="d2l-capture-central-content-list-no-results">
-				${this.localize('noResults')}
-			</div>
-		` : html``;
-	}
-
 	async reloadPage() {
 		this.loading = true;
 		this._videos = [];
@@ -238,4 +230,12 @@ export class CaptureCentralList extends DependencyRequester(InternalLocalizeMixi
 			this._start = 0;
 		}
 	}
+	renderNotFound() {
+		return !this.loading && this._videos.length === 0 ? html`
+			<div class="d2l-capture-central-content-list-no-results">
+				${this.localize('noResults')}
+			</div>
+		` : html``;
+	}
+
 }

--- a/applications/d2l-capture-central/src/components/capture-central-list.js
+++ b/applications/d2l-capture-central/src/components/capture-central-list.js
@@ -157,7 +157,7 @@ export class CaptureCentralList extends DependencyRequester(InternalLocalizeMixi
 		const { sortQuery, searchQuery, dateModified, dateCreated } = this.queryParams;
 
 		const searchFunc = this.page === '/recycle-bin' ? this._handleDeletedVideoSearch : this._handleVideoSearch;
-		searchFunc({
+		searchFunc.bind(this)({
 			append,
 			createdAt: dateCreated,
 			query: searchQuery,

--- a/applications/d2l-capture-central/src/components/capture-central-list.js
+++ b/applications/d2l-capture-central/src/components/capture-central-list.js
@@ -1,0 +1,242 @@
+import '@brightspace-ui/core/components/alert/alert-toast.js';
+import '@brightspace-ui/core/components/button/button-icon.js';
+import '@brightspace-ui/core/components/colors/colors.js';
+import '@brightspace-ui/core/components/icons/icon.js';
+import '@brightspace-ui/core/components/list/list-item.js';
+import '@brightspace-ui/core/components/list/list.js';
+import './content-file-drop.js';
+import './relative-date.js';
+
+import { bodyCompactStyles, bodySmallStyles } from '@brightspace-ui/core/components/typography/styles.js';
+import { css, html, LitElement } from 'lit-element/lit-element.js';
+import { observe, toJS } from 'mobx';
+
+import { contentSearchMixin } from '../mixins/content-search-mixin.js';
+import { DependencyRequester } from '../mixins/dependency-requester-mixin.js';
+import { InternalLocalizeMixin } from '../mixins/internal-localize-mixin.js';
+import { NavigationMixin } from '../mixins/navigation-mixin.js';
+import { navigationSharedStyle } from '../style/d2l-navigation-shared-styles.js';
+import { rootStore } from '../state/root-store.js';
+import { root } from '@polymer/polymer/lib/utils/path';
+
+export class CaptureCentralList extends DependencyRequester(InternalLocalizeMixin(NavigationMixin(contentSearchMixin(LitElement)))) {
+	static get properties() {
+		return {
+			loading: { type: Boolean, attribute: false },
+			page: {type: String, attribute: ""}
+		};
+	}
+
+	static get styles() {
+		return [bodyCompactStyles, bodySmallStyles, navigationSharedStyle, css`
+			:host([hidden]) {
+				display: none;
+			}
+
+			.title {
+				word-break: break-word;
+			}
+
+			#d2l-content-store-list {
+				padding-top: 1px;
+			}
+
+			.d2l-capture-central-content-list-no-results {
+				display: flex;
+				justify-content: center;
+				margin-top: 20px;
+			}
+
+			d2l-icon {
+				border-radius: 5px;
+				padding: 12px;
+				background-color: var(--d2l-color-celestine);
+				color: var(--d2l-color-white);
+			}
+		`];
+	}
+
+	constructor() {
+		super();
+		this.infiniteScrollThreshold = 400;
+		this.dateField = 'updatedAt';
+		this.loading = false;
+		this.alertToastMessage = '';
+		this.alertToastButtonText = '';
+
+		const {
+			searchQuery = '',
+			sortQuery = 'updatedAt:desc',
+			dateCreated = '',
+			dateModified = '',
+		} = rootStore.routingStore.getQueryParams();
+
+		this.queryParams = { searchQuery, sortQuery, dateCreated, dateModified};
+
+		window.addEventListener('scroll', this.onWindowScroll.bind(this));
+		this.observeQueryParams();
+	}
+
+	async addNewItemIntoContentItems(item) {
+		if (!item || !item.revision || !item.content || !item.upload) {
+			return;
+		}
+
+		const { title } = item.content;
+		const { id: revisionId, type } = item.revision;
+		const { id } = item.content;
+		const updatedAt = (new Date()).toISOString();
+
+		await this.insertIntoContentItemsBasedOnSort({
+			id, revisionId, type, title, updatedAt
+		});
+	}
+
+	areAnyFiltersActive() {
+		return this.queryParams.searchQuery ||
+			this.queryParams.dateModified ||
+			this.queryParams.dateCreated;
+	}
+
+	changeSort({ detail = {} }) {
+ 		const { sortKey, sortQuery } = detail;
+		if (/^(createdAt|updatedAt)$/.test(sortKey)) {
+			this.dateField = sortKey;
+		}
+
+		this._navigate(this.page, {
+			...this.queryParams,
+			sortQuery
+		}); 
+		}
+
+	getCompareBasedOnSort(item) {
+		const itemUpdatedAtDate = new Date(item.updatedAt);
+		switch (this.queryParams.sortQuery) {
+			case 'updatedAt:desc':
+				return e => {
+					const elementUpdatedAtDate = new Date(e.updatedAt);
+					return elementUpdatedAtDate <= itemUpdatedAtDate;
+				};
+
+			case 'updatedAt:asc':
+				return e => {
+					const elementUpdatedAtDate = new Date(e.updatedAt);
+					return elementUpdatedAtDate >= itemUpdatedAtDate;
+				};
+
+			case 'lastRevTitle.keyword:desc':
+				return e => {
+					return e.title.toLowerCase() <= item.title.toLowerCase();
+				};
+
+			case 'lastRevTitle.keyword:asc':
+				return e => {
+					return e.title.toLowerCase() >= item.title.toLowerCase();
+				};
+
+			default:
+				return () => true;
+		}
+	}
+
+	async insertIntoContentItemsBasedOnSort(item) {
+		let indexToInsertAt = this._videos.findIndex(this.getCompareBasedOnSort(item));
+		if (indexToInsertAt === -1) {
+			indexToInsertAt = this._videos.length;
+		}
+
+		if (!this._moreResultsAvailable || indexToInsertAt !== this._videos.length) {
+			this._videos.splice(indexToInsertAt, 0, item);
+			this.requestUpdate();
+			await this.updateComplete;
+		}
+	}
+
+	async loadNext({ append = true} = {}) {		
+		this.loading = true;
+		const { sortQuery, searchQuery, dateModified, dateCreated } = this.queryParams;
+
+		const func = this.page == '/recycle-bin' ? this._handleDeletedVideoSearch : this._handleVideoSearch();
+		func({
+			append,
+			createdAt: dateCreated,
+			query: searchQuery,
+			sort: sortQuery,
+			updatedAt: dateModified,
+		});
+
+		this.loading = false;
+	}
+
+	observeQueryParams() {
+		observe(
+			rootStore.routingStore,
+			'queryParams',
+			change => {
+				if (this.loading || rootStore.routingStore.page != this.page) {
+					return;
+				}
+
+				const {
+					searchQuery: updatedSearchQuery = '',
+					sortQuery: updatedSortQuery = 'updatedAt:desc',
+					dateCreated: updatedDateCreated = '',
+					dateModified: updatedDateModified = '',
+				} = toJS(change.newValue);
+
+				const { searchQuery, sortQuery, dateCreated, dateModified } =
+					this.queryParams;
+
+				if (updatedSearchQuery === searchQuery && updatedSortQuery === sortQuery &&
+					updatedDateCreated === dateCreated && updatedDateModified === dateModified
+				) {
+					return;
+				}
+
+				this.queryParams = {
+					searchQuery: updatedSearchQuery,
+					sortQuery: updatedSortQuery,
+					dateCreated: updatedDateCreated,
+					dateModified: updatedDateModified,
+					filter: this.page == 'recycle-bin' ? "DELETED" : undefined,
+				};
+				this.reloadPage();
+			}
+		);
+	}
+
+	onWindowScroll() {
+		const contentListElem = this.shadowRoot.querySelector('#d2l-content-store-list');
+		if (contentListElem) {
+			const bottom = contentListElem.getBoundingClientRect().top + window.pageYOffset + contentListElem.clientHeight;
+			const scrollY = window.pageYOffset + window.innerHeight;
+			if (bottom - scrollY < this.infiniteScrollThreshold && this._moreResultsAvailable && !this.loading) {
+				this.loadNext();
+			}
+		}
+	}
+
+	renderNotFound() {
+		return !this.loading && this._videos.length === 0 ? html`
+			<div class="d2l-capture-central-content-list-no-results">
+				${this.localize('noResults')}
+			</div>
+		` : html``;
+	}
+
+	async reloadPage() {
+		this.loading = true;
+		this._videos = [];
+		this._start = 0;
+		this._navigate(this.page, this.queryParams);
+
+		try {
+			await this.loadNext({ append: false });
+		} catch (error) {
+			this.loading = false;
+			this._videos = [];
+			this._start = 0;
+		}
+	}
+}

--- a/applications/d2l-capture-central/src/components/my-videos/content-list.js
+++ b/applications/d2l-capture-central/src/components/my-videos/content-list.js
@@ -9,7 +9,7 @@ import '../relative-date.js';
 import './content-list-header.js';
 import './content-list-item-ghost.js';
 import './content-list-item.js';
-import { CaptureCentralList } from'../capture-central-list.js';
+import { CaptureCentralList } from '../capture-central-list.js';
 
 import { html } from 'lit-element/lit-element.js';
 import { observe, toJS } from 'mobx';

--- a/applications/d2l-capture-central/src/components/my-videos/content-list.js
+++ b/applications/d2l-capture-central/src/components/my-videos/content-list.js
@@ -54,12 +54,6 @@ class ContentList extends CaptureCentralList {
 		`;
 	}
 
-	areAnyFiltersActive() {
-		return this.queryParams.searchQuery ||
-			this.queryParams.dateModified ||
-			this.queryParams.dateCreated;
-	}
-
 	contentListItemDeletedHandler(e) {
 		if (e && e.detail && e.detail.id) {
 			const { id } = e.detail;

--- a/applications/d2l-capture-central/src/components/my-videos/content-list.js
+++ b/applications/d2l-capture-central/src/components/my-videos/content-list.js
@@ -9,74 +9,17 @@ import '../relative-date.js';
 import './content-list-header.js';
 import './content-list-item-ghost.js';
 import './content-list-item.js';
+import { CaptureCentralList } from'../capture-central-list.js';
 
-import { bodyCompactStyles, bodySmallStyles } from '@brightspace-ui/core/components/typography/styles.js';
-import { css, html, LitElement } from 'lit-element/lit-element.js';
+import { html } from 'lit-element/lit-element.js';
 import { observe, toJS } from 'mobx';
 
-import { contentSearchMixin } from '../../mixins/content-search-mixin.js';
-import { DependencyRequester } from '../../mixins/dependency-requester-mixin.js';
-import { InternalLocalizeMixin } from '../../mixins/internal-localize-mixin.js';
-import { NavigationMixin } from '../../mixins/navigation-mixin.js';
-import { navigationSharedStyle } from '../../style/d2l-navigation-shared-styles.js';
 import { rootStore } from '../../state/root-store.js';
 
-class ContentList extends DependencyRequester(InternalLocalizeMixin(NavigationMixin(contentSearchMixin(LitElement)))) {
-	static get properties() {
-		return {
-			loading: { type: Boolean, attribute: false }
-		};
-	}
-
-	static get styles() {
-		return [bodyCompactStyles, bodySmallStyles, navigationSharedStyle, css`
-			:host([hidden]) {
-				display: none;
-			}
-
-			.title {
-				word-break: break-word;
-			}
-
-			#d2l-content-store-list {
-				padding-top: 1px;
-			}
-
-			.d2l-capture-central-content-list-no-results {
-				display: flex;
-				justify-content: center;
-				margin-top: 20px;
-			}
-
-			d2l-icon {
-				border-radius: 5px;
-				padding: 12px;
-				background-color: var(--d2l-color-celestine);
-				color: var(--d2l-color-white);
-			}
-		`];
-	}
-
+class ContentList extends CaptureCentralList {
 	constructor() {
 		super();
-		this.infiniteScrollThreshold = 400;
-		this.dateField = 'updatedAt';
-		this.loading = false;
-		this.alertToastMessage = '';
-		this.alertToastButtonText = '';
-		this.undoDeleteObject = {};
-
-		const {
-			searchQuery = '',
-			sortQuery = 'updatedAt:desc',
-			dateCreated = '',
-			dateModified = ''
-		} = rootStore.routingStore.getQueryParams();
-
-		this.queryParams = { searchQuery, sortQuery, dateCreated, dateModified };
-
-		window.addEventListener('scroll', this.onWindowScroll.bind(this));
-		this.observeQueryParams();
+		this.page = '/my-videos';
 	}
 
 	connectedCallback() {
@@ -111,37 +54,10 @@ class ContentList extends DependencyRequester(InternalLocalizeMixin(NavigationMi
 		`;
 	}
 
-	async addNewItemIntoContentItems(item) {
-		if (!item || !item.revision || !item.content || !item.upload) {
-			return;
-		}
-
-		const { title } = item.content;
-		const { id: revisionId, type } = item.revision;
-		const { id } = item.content;
-		const updatedAt = (new Date()).toISOString();
-
-		await this.insertIntoContentItemsBasedOnSort({
-			id, revisionId, type, title, updatedAt
-		});
-	}
-
 	areAnyFiltersActive() {
 		return this.queryParams.searchQuery ||
 			this.queryParams.dateModified ||
 			this.queryParams.dateCreated;
-	}
-
-	changeSort({ detail = {} }) {
-		const { sortKey, sortQuery } = detail;
-		if (/^(createdAt|updatedAt)$/.test(sortKey)) {
-			this.dateField = sortKey;
-		}
-
-		this._navigate('/my-videos', {
-			...this.queryParams,
-			sortQuery
-		});
 	}
 
 	contentListItemDeletedHandler(e) {
@@ -181,99 +97,6 @@ class ContentList extends DependencyRequester(InternalLocalizeMixin(NavigationMi
 		}
 	}
 
-	getCompareBasedOnSort(item) {
-		const itemUpdatedAtDate = new Date(item.updatedAt);
-		switch (this.queryParams.sortQuery) {
-			case 'updatedAt:desc':
-				return e => {
-					const elementUpdatedAtDate = new Date(e.updatedAt);
-					return elementUpdatedAtDate <= itemUpdatedAtDate;
-				};
-
-			case 'updatedAt:asc':
-				return e => {
-					const elementUpdatedAtDate = new Date(e.updatedAt);
-					return elementUpdatedAtDate >= itemUpdatedAtDate;
-				};
-
-			case 'lastRevTitle.keyword:desc':
-				return e => {
-					return e.title.toLowerCase() <= item.title.toLowerCase();
-				};
-
-			case 'lastRevTitle.keyword:asc':
-				return e => {
-					return e.title.toLowerCase() >= item.title.toLowerCase();
-				};
-
-			default:
-				return () => true;
-		}
-	}
-
-	async insertIntoContentItemsBasedOnSort(item) {
-		let indexToInsertAt = this._videos.findIndex(this.getCompareBasedOnSort(item));
-		if (indexToInsertAt === -1) {
-			indexToInsertAt = this._videos.length;
-		}
-
-		if (!this._moreResultsAvailable || indexToInsertAt !== this._videos.length) {
-			this._videos.splice(indexToInsertAt, 0, item);
-			this.requestUpdate();
-			await this.updateComplete;
-		}
-	}
-
-	async loadNext({ append = true } = {}) {
-		this.loading = true;
-		const { sortQuery, searchQuery, dateModified, dateCreated } = this.queryParams;
-		await this._handleVideoSearch({
-			append,
-			createdAt: dateCreated,
-			query: searchQuery,
-			sort: sortQuery,
-			updatedAt: dateModified,
-		});
-
-		this.loading = false;
-	}
-
-	observeQueryParams() {
-		observe(
-			rootStore.routingStore,
-			'queryParams',
-			change => {
-				if (this.loading) {
-					return;
-				}
-
-				const {
-					searchQuery: updatedSearchQuery = '',
-					sortQuery: updatedSortQuery = 'updatedAt:desc',
-					dateCreated: updatedDateCreated = '',
-					dateModified: updatedDateModified = ''
-				} = toJS(change.newValue);
-
-				const { searchQuery, sortQuery, dateCreated, dateModified } =
-					this.queryParams;
-
-				if (updatedSearchQuery === searchQuery && updatedSortQuery === sortQuery &&
-					updatedDateCreated === dateCreated && updatedDateModified === dateModified
-				) {
-					return;
-				}
-
-				this.queryParams = {
-					searchQuery: updatedSearchQuery,
-					sortQuery: updatedSortQuery,
-					dateCreated: updatedDateCreated,
-					dateModified: updatedDateModified
-				};
-				this.reloadPage();
-			}
-		);
-	}
-
 	observeSuccessfulUpload() {
 		observe(
 			this.uploader,
@@ -286,32 +109,6 @@ class ContentList extends DependencyRequester(InternalLocalizeMixin(NavigationMi
 				}
 			}
 		);
-	}
-
-	onWindowScroll() {
-		const contentListElem = this.shadowRoot.querySelector('#d2l-content-store-list');
-		if (contentListElem) {
-			const bottom = contentListElem.getBoundingClientRect().top + window.pageYOffset + contentListElem.clientHeight;
-			const scrollY = window.pageYOffset + window.innerHeight;
-			if (bottom - scrollY < this.infiniteScrollThreshold && this._moreResultsAvailable && !this.loading) {
-				this.loadNext();
-			}
-		}
-	}
-
-	async reloadPage() {
-		this.loading = true;
-		this._videos = [];
-		this._start = 0;
-		this._navigate('/my-videos', this.queryParams);
-
-		try {
-			await this.loadNext({ append: false });
-		} catch (error) {
-			this.loading = false;
-			this._videos = [];
-			this._start = 0;
-		}
 	}
 
 	renderContentItem(item) {
@@ -337,14 +134,6 @@ class ContentList extends DependencyRequester(InternalLocalizeMixin(NavigationMi
 				<content-list-item-ghost ?hidden=${!this.loading}></content-list-item-ghost>
 			</d2l-list>
 		`);
-	}
-
-	renderNotFound() {
-		return !this.loading && this._videos.length === 0 ? html`
-			<div class="d2l-capture-central-content-list-no-results">
-				${this.localize('noResults')}
-			</div>
-		` : html``;
 	}
 
 	showUndoDeleteToast() {

--- a/applications/d2l-capture-central/src/mixins/content-search-mixin.js
+++ b/applications/d2l-capture-central/src/mixins/content-search-mixin.js
@@ -22,6 +22,30 @@ export const contentSearchMixin = superClass => class extends superClass {
 		this._totalResults = 0;
 	}
 
+	async _handleDeletedVideoSearch({
+		append = false,
+		query = this._query,
+		createdAt,
+		sort = '',
+		updatedAt
+	} = {}) {
+		if (append) {
+			this._start += this._resultSize;
+		}
+
+		const { hits: { hits, total } } = await this.apiClient.searchDeletedContent({
+			contentType: 'video',
+			createdAt: createdAt,
+			includeThumbnails: false,
+			query: query,
+			sort: sort,
+			start: this._start,
+			updatedAt: updatedAt
+		});
+		this._updateVideoList(hits, append);
+		this._totalResults = total;
+		this._moreResultsAvailable = this._videos.length < total;
+	}
 	async _handleInputVideoSearch({ detail: { value: query } }) {
 		this._start = 0;
 		this._query = query;

--- a/applications/d2l-capture-central/src/util/content-service-client.js
+++ b/applications/d2l-capture-central/src/util/content-service-client.js
@@ -192,6 +192,7 @@ export default class ContentServiceClient {
 				query,
 				contentType: contentFilterToSearchQuery(contentType),
 				updatedAt: dateFilterToSearchQuery(updatedAt),
+				createdAt: dateFilterToSearchQuery(createdAt),
 				filter: 'DELETED',
 				includeThumbnails
 			},

--- a/applications/d2l-capture-central/src/util/content-service-client.js
+++ b/applications/d2l-capture-central/src/util/content-service-client.js
@@ -169,6 +169,37 @@ export default class ContentServiceClient {
 		});
 	}
 
+	searchDeletedContent({
+		start = 0,
+		size = 15,
+		sort = 'updatedAt:desc',
+		query = '',
+		contentType = '',
+		updatedAt = '',
+		createdAt = '',
+		includeThumbnails = false
+	}) {
+		console.log('SEARCHING DELETED CONTENT');
+		const headers = new Headers();
+		headers.append('pragma', 'no-cache');
+		headers.append('cache-control', 'no-cache');
+
+		return this._fetch({
+			path: `/api/${this.tenantId}/search/content`,
+			query: {
+				start,
+				size,
+				sort,
+				query,
+				contentType: contentFilterToSearchQuery(contentType),
+				updatedAt: dateFilterToSearchQuery(updatedAt),
+				filter: 'DELETED',
+				includeThumbnails
+			},
+			headers
+		});
+	}
+
 	signUploadRequest({
 		fileName,
 		contentType,

--- a/applications/d2l-capture-central/src/util/content-service-client.js
+++ b/applications/d2l-capture-central/src/util/content-service-client.js
@@ -179,7 +179,6 @@ export default class ContentServiceClient {
 		createdAt = '',
 		includeThumbnails = false
 	}) {
-		console.log('SEARCHING DELETED CONTENT');
 		const headers = new Headers();
 		headers.append('pragma', 'no-cache');
 		headers.append('cache-control', 'no-cache');


### PR DESCRIPTION
Move some methods out of ContentList and into a new class so that RecycleBin and ContentList can share those methods (will add RecycleBin in a separate PR)