### PR TITLE
Fix 'Edit Live Event' page breaking after first time it is viewed

### DIFF
--- a/applications/d2l-capture-central/src/state/routing-store.js
+++ b/applications/d2l-capture-central/src/state/routing-store.js
@@ -57,9 +57,9 @@ export class RoutingStore {
 		this.orgUnitId = orgUnitId;
 		this.page = page;
 		this.params = routeCtx.params;
+		this.subView = subView;
 		this.queryParams = queryParams;
 		this.routeCtx = routeCtx;
-		this.subView = subView;
 	}
 
 	setSubView(subView) {


### PR DESCRIPTION
[The 'Edit Live Event' page observes the query parameters in the routing store. When they change, it then checks if the subView (the last part of the URL) is set to 'edit' before reloading the page content.](https://github.com/Brightspace/content-components/blob/a714fcdbef9f6b675d95889db68124d7ecbde4ed/applications/d2l-capture-central/src/pages/live-events/d2l-capture-central-live-events-edit.js#L122)

The issue was that the query parameters in the routing store were being updated BEFORE the subView, causing the page to reload at the wrong time with incorrect query parameters.

The solution is simply to update the routing store's subView value before updating the query parameters, to ensure the page always reloads as expected.