### PR TITLE
fix: Stop landing page from always redirecting to 404

### DIFF
--- a/applications/d2l-capture-central/src/d2l-capture-central-app.js
+++ b/applications/d2l-capture-central/src/d2l-capture-central-app.js
@@ -194,6 +194,10 @@ class D2lCaptureCentralApp extends DependencyRequester(NavigationMixin(InternalL
 			*/
 			case pageNames.videos:
 				import('./pages/videos/d2l-capture-central-videos.js');
+				if (rootStore.routingStore.previousPage === '') {
+					// Ensures the DOM updates when redirecting from the initial landing page. Otherwise, the app shows a blank page.
+					this.requestUpdate();
+				}
 				return;
 			/*
 			case pageNames.viewLiveEvent:

--- a/applications/d2l-capture-central/src/pages/d2l-capture-central-landing.js
+++ b/applications/d2l-capture-central/src/pages/d2l-capture-central-landing.js
@@ -16,8 +16,7 @@ class D2lCaptureCentralLanding extends DependencyRequester(navigationMixin(PageV
 
 	connectedCallback() {
 		super.connectedCallback();
-		const permissions = rootStore.permissionStore.getPermissions();
-		if (permissions.canManage) {
+		if (rootStore.permissionStore.getCanAccessCaptureCentral()) {
 			this._navigate('/videos');
 		} else {
 			this._navigate('/404');

--- a/applications/d2l-capture-central/src/state/permission-store.js
+++ b/applications/d2l-capture-central/src/state/permission-store.js
@@ -7,6 +7,10 @@ export class PermissionStore {
 		this.permissions = {};
 	}
 
+	getCanAccessCaptureCentral() {
+		return this.permissions.canAccessCaptureCentral === 'true';
+	}
+
 	getCanManageAllVideos() {
 		return this.permissions.canManageAllVideos === 'true';
 	}


### PR DESCRIPTION
Originally, the landing page checked the value of the "Can Manage Capture Central" variable. If false, it would redirect to 404 to prevent user access. The previous code used an incorrect variable reference, hence the landing page always redirected to 404.

The proper permission to use in this case would be "Can _Access_ Capture Central", rather than "Can _Manage_ Capture Central". To fix that, this commit adds a getter for "Can Access Capture Central"" in `PermissionStore` and updates the landing page to use it.