### PR TITLE
US135504: Inform user file is being processed & poll until ready

### DIFF
--- a/core/d2l-content-viewer/locales/en.js
+++ b/core/d2l-content-viewer/locales/en.js
@@ -5,4 +5,5 @@ export const val = {
 	formatLD: 'LD',
 	formatMP3: 'MP3',
 	formatSD: 'SD',
+	mediaFileIsProcessing: 'This media file is currently being processed. Please come back later.'
 };


### PR DESCRIPTION
When an audio/video revision is not yet ready, `d2l-content-viewer` will display a message instead of the Media Player. The revision's "ready" status will be polled every 10 seconds. When it becomes ready, the component will automatically reload and display the Media Player.

<img width="1118" alt="Media File Processing" src="https://user-images.githubusercontent.com/9592685/151846997-f520bec7-7efa-47d3-9fb0-474f9fe9d6bd.png">

For consistency, I've also edited the "This media file has been deleted" message to use the same styling.

<img width="1106" alt="Media File Deleted" src="https://user-images.githubusercontent.com/9592685/151847002-d414da43-b0cd-4a80-b579-a2b92db68f2a.png">