### PR TITLE
fix: Fix d2l-content-uploader not displaying preview when SD is missing

### DIFF
--- a/core/d2l-content-uploader/locales/en.js
+++ b/core/d2l-content-uploader/locales/en.js
@@ -17,6 +17,7 @@ export const val = {
 	formatSD: 'SD',
 	invalidFileType: 'Invalid file type.',
 	mayOnlyUpload1File: 'You may only upload 1 file.',
+	mediaFileFailedProcessing: 'This media file failed to be processed',
 	mediaFileIsProcessing: 'Your media file is now being processed.\nPlease wait, or save and come back later.\nYou will receive a notification when processing is complete.',
 	or: 'or',
 	remove: 'Remove',

--- a/core/d2l-content-uploader/src/util/content-service-client.js
+++ b/core/d2l-content-uploader/src/util/content-service-client.js
@@ -134,7 +134,7 @@ export default class ContentServiceClient {
 
 		const response = await d2lfetch.fetch(request);
 		if (!response.ok) {
-			throw new Error(response.statusText);
+			throw new Error(response.statusText, { cause: response.status });
 		}
 
 		if (extractJsonBody) {


### PR DESCRIPTION
Because of the recent cost-cutting changes to transcoding, a video file might not have an SD transcode available.

After uploading, d2l-content-uploader's Preview page tries to load both SD and HD formats. If SD doesn't exist, the 404 causes the dialog to break.

To fix this, we now check for 404 when fetching each media format. If a 404 is received, then that format isn't passed to the Media Player.

In the exceptional case where all formats return 404, meaning no transcodes were produced, we display a "This media file failed to be processed" error.