### PR TITLE
Possible fix for capture central editing in Staging

### DIFF
--- a/applications/d2l-capture-central/src/pages/producer/d2l-capture-central-producer.js
+++ b/applications/d2l-capture-central/src/pages/producer/d2l-capture-central-producer.js
@@ -47,7 +47,7 @@ class D2LCaptureCentralProducer extends DependencyRequester(PageViewElement) {
 	}
 
 	render() {
-		if (this._loading) {
+		if (this._loading || !this.rootStore.routingStore.params.id) {
 			return html`<d2l-loading-spinner size=150></d2l-loading-spinner>`;
 		}
 


### PR DESCRIPTION
Producer doesn't load for Capture Central editing in Staging, possibly because the content id isn't ready at the time of rendering.