### PR TITLE
US136314 - lit 2 upgrade non-breaking

### DIFF
--- a/applications/d2l-capture-central/src/components/capture-central-live-events.js
+++ b/applications/d2l-capture-central/src/components/capture-central-live-events.js
@@ -136,7 +136,7 @@ class CaptureCentralLiveEvents extends DependencyRequester(InternalLocalizeMixin
 	}
 
 	hideAlerts() {
-		const inlineCriticalAlertElement = this.shadowRoot.querySelector('#live-events-inline-critical-alert');
+		const inlineCriticalAlertElement = this.shadowRoot && this.shadowRoot.querySelector('#live-events-inline-critical-alert');
 		if (inlineCriticalAlertElement) {
 			inlineCriticalAlertElement.style.display = 'none';
 			this._alertMessage = '';

--- a/applications/d2l-capture-central/src/components/content-filter-dropdown.js
+++ b/applications/d2l-capture-central/src/components/content-filter-dropdown.js
@@ -95,7 +95,7 @@ class ContentFilterDropdown extends DependencyRequester(RtlMixin(InternalLocaliz
 	}
 
 	get filterOptions() {
-		return this.shadowRoot.querySelectorAll('select');
+		return this.shadowRoot ? this.shadowRoot.querySelectorAll('select') : [];
 	}
 
 	observeQueryParams() {

--- a/applications/d2l-capture-central/src/components/live-event-form.js
+++ b/applications/d2l-capture-central/src/components/live-event-form.js
@@ -143,6 +143,8 @@ class LiveEventForm extends MobxReactionUpdate(NavigationMixin(RtlMixin(Internal
 	}
 
 	getPresentationLayoutSelection() {
+		if (!this.shadowRoot) return layoutNames.default;
+
 		const layoutCameraInputElement = this.shadowRoot.querySelector('#presentation-layout-camera');
 		const layoutScreenInputElement = this.shadowRoot.querySelector('#presentation-layout-screen');
 		const layoutCameraAndScreenInputElement = this.shadowRoot.querySelector('#presentation-layout-camera-and-screen');
@@ -163,14 +165,14 @@ class LiveEventForm extends MobxReactionUpdate(NavigationMixin(RtlMixin(Internal
 	}
 
 	hideAccordions() {
-		const accessControlAccordionElement = this.shadowRoot.querySelector('#access-control-accordion');
+		const accessControlAccordionElement = this.shadowRoot && this.shadowRoot.querySelector('#access-control-accordion');
 		if (accessControlAccordionElement) {
 			accessControlAccordionElement.removeAttribute('opened');
 		}
 	}
 
 	hideFailureAlert() {
-		const criticalAlert = this.shadowRoot.querySelector('#live-event-form-critical-alert');
+		const criticalAlert = this.shadowRoot && this.shadowRoot.querySelector('#live-event-form-critical-alert');
 		if (criticalAlert) {
 			criticalAlert.style.display = 'none';
 			const inputContainerElement = this.shadowRoot.querySelector('#input-container');
@@ -181,6 +183,8 @@ class LiveEventForm extends MobxReactionUpdate(NavigationMixin(RtlMixin(Internal
 	}
 
 	reload() {
+		if (!this.shadowRoot) return;
+
 		const titleInputElement = this.shadowRoot.querySelector('#title-input');
 		if (titleInputElement) {
 			titleInputElement.value = '';
@@ -225,7 +229,7 @@ class LiveEventForm extends MobxReactionUpdate(NavigationMixin(RtlMixin(Internal
 	}
 
 	renderFailureAlert({ message, hideInputs = false}) {
-		const criticalAlert = this.shadowRoot.querySelector('#live-event-form-critical-alert');
+		const criticalAlert = this.shadowRoot && this.shadowRoot.querySelector('#live-event-form-critical-alert');
 		if (criticalAlert) {
 			this._alertMessage = message;
 			criticalAlert.style.display = 'block';
@@ -245,7 +249,7 @@ class LiveEventForm extends MobxReactionUpdate(NavigationMixin(RtlMixin(Internal
 	}
 
 	setFocus() {
-		const titleInputElement = this.shadowRoot.querySelector('#title-input');
+		const titleInputElement = this.shadowRoot && this.shadowRoot.querySelector('#title-input');
 		if (titleInputElement) {
 			titleInputElement.focus();
 		}
@@ -253,6 +257,7 @@ class LiveEventForm extends MobxReactionUpdate(NavigationMixin(RtlMixin(Internal
 
 	setLiveEvent(liveEvent) {
 		this._liveEvent = liveEvent;
+		if (!this.shadowRoot) return;
 
 		const titleInputElement = this.shadowRoot.querySelector('#title-input');
 		if (titleInputElement) {
@@ -292,6 +297,8 @@ class LiveEventForm extends MobxReactionUpdate(NavigationMixin(RtlMixin(Internal
 	}
 
 	setPresentationLayoutSelection({ layoutName }) {
+		if (!this.shadowRoot) return;
+
 		const layoutCameraInputElement = this.shadowRoot.querySelector('#presentation-layout-camera');
 		const layoutScreenInputElement = this.shadowRoot.querySelector('#presentation-layout-screen');
 		const layoutCameraAndScreenInputElement = this.shadowRoot.querySelector('#presentation-layout-camera-and-screen');

--- a/applications/d2l-capture-central/src/pages/live-events/d2l-capture-central-live-events-create.js
+++ b/applications/d2l-capture-central/src/pages/live-events/d2l-capture-central-live-events-create.js
@@ -105,7 +105,7 @@ class D2LCaptureLiveEventsCreate extends DependencyRequester(PageViewElement) {
 	}
 
 	async reloadPage() {
-		if (!rootStore.permissionStore.getCanManageLiveEvents()) {
+		if (!rootStore.permissionStore.getCanManageLiveEvents() || !this.shadowRoot) {
 			return;
 		}
 

--- a/applications/d2l-capture-central/src/pages/live-events/d2l-capture-central-live-events-edit.js
+++ b/applications/d2l-capture-central/src/pages/live-events/d2l-capture-central-live-events-edit.js
@@ -137,7 +137,7 @@ class D2LCaptureLiveEventsEdit extends DependencyRequester(PageViewElement) {
 	}
 
 	async reloadPage() {
-		if (!rootStore.permissionStore.getCanManageLiveEvents()) {
+		if (!rootStore.permissionStore.getCanManageLiveEvents() || !this.shadowRoot) {
 			return;
 		}
 

--- a/applications/d2l-content-store/src/components/content-filter-dropdown.js
+++ b/applications/d2l-content-store/src/components/content-filter-dropdown.js
@@ -104,7 +104,7 @@ class ContentFilterDropdown extends DependencyRequester(RtlMixin(InternalLocaliz
 	}
 
 	get filterOptions() {
-		return this.shadowRoot.querySelectorAll('select');
+		return this.shadowRoot ? this.shadowRoot.querySelectorAll('select') : [];
 	}
 
 	getFilterText() {

--- a/capture/d2l-capture-producer/d2l-capture-producer-editor.js
+++ b/capture/d2l-capture-producer/d2l-capture-producer-editor.js
@@ -21,7 +21,7 @@ import { InternalLocalizeMixin } from './src/internal-localize-mixin.js';
 import { bodyCompactStyles, labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 import { selectStyles } from '@brightspace-ui/core/components/inputs/input-select-styles.js';
-import { styleMap } from 'lit-html/directives/style-map';
+import { styleMap } from 'lit-html/directives/style-map.js';
 import { Timeline } from './src/timeline';
 import { convertVttCueArrayToVttText, textTrackCueListToArray } from './src/captions-utils.js';
 

--- a/capture/d2l-capture-producer/d2l-capture-producer.js
+++ b/capture/d2l-capture-producer/d2l-capture-producer.js
@@ -321,7 +321,7 @@ class CaptureProducer extends RtlMixin(InternalLocalizeMixin(LitElement)) {
 	}
 
 	get _editor() {
-		return this.shadowRoot.querySelector('d2l-capture-producer-editor');
+		return this.shadowRoot && this.shadowRoot.querySelector('d2l-capture-producer-editor');
 	}
 
 	get _enableCutsAndChapters() {

--- a/capture/d2l-capture-producer/demo/demo-video-producer.js
+++ b/capture/d2l-capture-producer/demo/demo-video-producer.js
@@ -365,7 +365,7 @@ class DemoVideoProducer extends LitElement {
 	}
 
 	get _producer() {
-		return this.shadowRoot.querySelector('d2l-capture-producer-editor');
+		return this.shadowRoot && this.shadowRoot.querySelector('d2l-capture-producer-editor');
 	}
 
 	_renderSavedUnsavedIndicator() {

--- a/core/d2l-captions-manager/src/components/captions-upload.js
+++ b/core/d2l-captions-manager/src/components/captions-upload.js
@@ -98,7 +98,7 @@ class CaptionsUpload extends RtlMixin(InternalLocalizeMixin(LitElement)) {
 	}
 
 	resetSelection() {
-		const languageSelectElement = this.shadowRoot.querySelector('#captions-add-language-selector');
+		const languageSelectElement = this.shadowRoot && this.shadowRoot.querySelector('#captions-add-language-selector');
 		if (languageSelectElement) {
 			languageSelectElement.value = this.selectALanguageOptionValue;
 		}


### PR DESCRIPTION
This PR makes backwards-compatible changes to prepare this repo for a Lit 2 upgrade. Since the changes are backwards compatible, it can be merged right away.
Non-breaking change checklist:
- [x] Add missing `.js` extensions for lit-html or lit-element imports
- [x] `await requestUpdate` -> `await elem.updateComplete`
- [x] add non-null checks to shadowRoot accesses (not including test files)
- [x] audit usages of `unsafeHTML` to ensure `null`, `undefined` inputs are handled as expected
- [x] remove dynamic code from inside  `<template>` tags (Lit files only)
- [x] remove any dependencies on old Lit versions
- [x] audit `ifDefined` usages for null parameters

For more information on the Lit 2 upgrade, visit https://lit.dev/docs/releases/upgrade/ or contact team Gaudi.