### PR TITLE
capture central upload size and file type restrictions

### DIFF
--- a/applications/d2l-capture-central/locales/en.js
+++ b/applications/d2l-capture-central/locales/en.js
@@ -50,6 +50,7 @@ export const val = {
 	everyonesVideos: 'Everyone\'s Videos',
 	export: 'Export',
 	exportAsCsv: 'Export as a list of comma-separated values.',
+	fileTooLarge: 'File size is larger than {localizedMaxFileSize}.',
 	filterCount: '{count, plural, =0 {Filter} =1 {Filter ({count})} other {Filters ({count})}}',
 	finish: 'Finish',
 	finishing: 'Finishing…',

--- a/applications/d2l-capture-central/src/components/capture-central-list.js
+++ b/applications/d2l-capture-central/src/components/capture-central-list.js
@@ -4,7 +4,6 @@ import '@brightspace-ui/core/components/colors/colors.js';
 import '@brightspace-ui/core/components/icons/icon.js';
 import '@brightspace-ui/core/components/list/list-item.js';
 import '@brightspace-ui/core/components/list/list.js';
-import './content-file-drop.js';
 import './relative-date.js';
 
 import { bodyCompactStyles, bodySmallStyles } from '@brightspace-ui/core/components/typography/styles.js';

--- a/applications/d2l-capture-central/src/components/recycle-bin/recycle-bin-list.js
+++ b/applications/d2l-capture-central/src/components/recycle-bin/recycle-bin-list.js
@@ -4,7 +4,6 @@ import '@brightspace-ui/core/components/colors/colors.js';
 import '@brightspace-ui/core/components/icons/icon.js';
 import '@brightspace-ui/core/components/list/list-item.js';
 import '@brightspace-ui/core/components/list/list.js';
-import '../content-file-drop.js';
 import '../relative-date.js';
 import './recycle-bin-list-header.js';
 import './recycle-bin-item-ghost.js';
@@ -28,7 +27,6 @@ class RecycleBinList extends CaptureCentralList {
 	render() {
 		return html`
 			<recycle-bin-list-header @change-sort=${this.changeSort}></recycle-bin-list-header>
-			<content-file-drop>
 			<d2l-list>
 				<div id="d2l-content-store-list">
 					${this.renderNotFound()}
@@ -36,7 +34,6 @@ class RecycleBinList extends CaptureCentralList {
 					${this.renderGhosts()}
 				</div>
 			</d2l-list>
-			</content-file-drop>
 
 			<d2l-alert-toast
 				id="recycle-bin-toast"

--- a/applications/d2l-capture-central/src/components/videos/content-list.js
+++ b/applications/d2l-capture-central/src/components/videos/content-list.js
@@ -41,7 +41,7 @@ class ContentList extends CaptureCentralList {
 				@change-sort=${this.changeSort}
 				?can-transfer-ownership=${this.canTransferOwnership}
 			></content-list-header>
-			<content-file-drop>
+			<content-file-drop @file-drop-error=${this.fileDropErrorHandler}>
 			<d2l-list>
 				<div id="d2l-content-store-list">
 					${this.renderNotFound()}
@@ -58,6 +58,13 @@ class ContentList extends CaptureCentralList {
 				announce-text=${this.alertToastMessage}
 				@d2l-alert-button-pressed=${this.undoDeleteHandler}>
 				${this.alertToastMessage}
+			</d2l-alert-toast>
+
+			<d2l-alert-toast
+				id="file-drop-toast"
+				type="error"
+				announce-text=${this.fileDropErrorMessage}>
+				${this.fileDropErrorMessage}
 			</d2l-alert-toast>
 		`;
 	}
@@ -115,6 +122,15 @@ class ContentList extends CaptureCentralList {
 				this._videos[index][this.dateField] = (new Date()).toISOString();
 				this.requestUpdate();
 			}
+		}
+	}
+
+	fileDropErrorHandler(e) {
+		const errorToastElement = this.shadowRoot.querySelector('#file-drop-toast');
+		if (e && e.detail && e.detail.message && errorToastElement) {
+			this.fileDropErrorMessage = e.detail.message;
+			this.requestUpdate();
+			errorToastElement.setAttribute('open', true);
 		}
 	}
 

--- a/applications/d2l-capture-central/src/util/constants.js
+++ b/applications/d2l-capture-central/src/util/constants.js
@@ -35,3 +35,5 @@ export const sortNames = {
 	status: 'status',
 	default: 'startTime'
 };
+
+export const maxFileSizeInBytes = 5 * 1024 * 1024 * 1024;

--- a/applications/d2l-capture-central/src/util/media-type-util.js
+++ b/applications/d2l-capture-central/src/util/media-type-util.js
@@ -1,0 +1,13 @@
+const SUPPORTED_VIDEO_EXTENSIONS = ['.avi', '.f4v', '.flv', '.m4v', '.mov', '.mp4', '.webm', '.wmv'];
+
+export function getExtension(filePath) {
+	return filePath.split('.').pop().toLowerCase();
+}
+
+export function getSupportedExtensions() {
+	return SUPPORTED_VIDEO_EXTENSIONS;
+}
+
+export function isSupported(filePath) {
+	return getSupportedExtensions().includes(`.${getExtension(filePath)}`);
+}


### PR DESCRIPTION
- added 5GB limit to match max file size for s3 upload (not multipart)
- restricted upload to allow only the supported video types
- removed drag and drop upload from recycle bin