### PR TITLE
feat: Access preview by clicking on video row or "Preview" option (US136519)

### DIFF
--- a/applications/d2l-capture-central/locales/en.js
+++ b/applications/d2l-capture-central/locales/en.js
@@ -109,6 +109,7 @@ export const val = {
 	preRollClip: 'Pre-roll clip:',
 	presentationLayout: 'Presentation Layout',
 	presenter: 'Presenter',
+	preview: 'Preview',
 	publish: 'Publish',
 	publishError: 'An error occurred during publishing.',
 	publishSuccess: 'Published successfully.',

--- a/applications/d2l-capture-central/src/components/videos/content-list-item.js
+++ b/applications/d2l-capture-central/src/components/videos/content-list-item.js
@@ -74,9 +74,12 @@ class ContentListItem extends DependencyRequester(navigationMixin(InternalLocali
 	}
 
 	render() {
+		const previewUrl = `./${pageNames.preview}/${this.id}/${this.revisionId}`;
+
 		return html`
 			<d2l-list-item class="d2l-body-compact"
 				?disabled=${this.disabled}
+				href="${previewUrl}"
 				label="${this.title}"
 				?selectable=${this.selectable}
 				key=${this.id}
@@ -99,15 +102,10 @@ class ContentListItem extends DependencyRequester(navigationMixin(InternalLocali
 				</content-list-columns>
 
 				<div slot="actions" id="actions" class="actions">
-					<d2l-button-icon
-						@click=${this._goTo(`/${pageNames.preview}/${this.id}/${this.revisionId}`)}
-						text="${this.localize('preview')}"
-						icon="tier1:preview"
-						?disabled=${this.disabled}
-					></d2l-button-icon>
 					<d2l-dropdown-more text="${this.localize('moreActions')}" @click=${this.dropdownClicked} ?disabled=${this.disabled}>
 						<d2l-dropdown-menu id="actions-dropdown-menu" align="end" boundary=${JSON.stringify(this.dropdownBoundary)}>
 							<d2l-menu label="${this.localize('moreActions')}">
+								<d2l-menu-item text="${this.localize('preview')}" @click=${this._goTo(previewUrl)}></d2l-menu-item>
 								<d2l-menu-item text="${this.localize('download')}" @click="${this.download}"></d2l-menu-item>
 								<d2l-menu-item text="${this.localize('edit')}" @click=${this._goTo(`/${pageNames.producer}/${this.id}`)}></d2l-menu-item>
 								<d2l-menu-item id="rename-initiator" text="${this.localize('rename')}" @click="${this.openDialog()}"></d2l-menu-item>


### PR DESCRIPTION
The "Preview" page can now be accessed in two ways:

- Clicking anywhere on a video list item
- Opening a video list item's menu and selecting "Preview" (this replaces the "Preview" icon button that we previously had)

<img width="1197" alt="Capture Central - Preview option" src="https://user-images.githubusercontent.com/9592685/155414611-490416f2-8755-4027-9b14-3e5b59eda327.png">
