### PR TITLE
Use revision.id for captions

### DIFF
--- a/applications/d2l-capture-central/src/pages/preview/d2l-capture-central-preview.js
+++ b/applications/d2l-capture-central/src/pages/preview/d2l-capture-central-preview.js
@@ -118,7 +118,7 @@ class D2LCaptureCentralPreview extends DependencyRequester(PageViewElement) {
 	async loadCaptions(locale) {
 		const res = await this.apiClient.getCaptionsUrl({
 			contentId: this.id,
-			revisionId: this.revisionId,
+			revisionId: this.revision.id,
 			locale: locale
 		});
 		res.locale = locale;


### PR DESCRIPTION
Was using the revisionId instead of revision.id (missed this change in #222) which resulted in captions not loading. Possibly related to https://trello.com/c/vNitHy0t/