### PR TITLE
use clientApp in capture central upload/search

### DIFF
--- a/applications/d2l-capture-central/src/mixins/content-search-mixin.js
+++ b/applications/d2l-capture-central/src/mixins/content-search-mixin.js
@@ -1,5 +1,7 @@
 import { formatDate } from '@brightspace-ui/intl/lib/dateTime.js';
 
+const clientApps = ['LmsContent', 'LmsCourseImport', 'LmsCapture', 'Capture', 'none'];
+
 export const contentSearchMixin = superClass => class extends superClass {
 	static get properties() {
 		return {
@@ -57,6 +59,7 @@ export const contentSearchMixin = superClass => class extends superClass {
 
 		const { hits: { hits, total } } = await this.apiClient.searchDeletedContent({
 			contentType: 'video',
+			clientApps: clientApps.join(','),
 			createdAt: createdAt,
 			includeThumbnails: false,
 			query: query,
@@ -97,6 +100,7 @@ export const contentSearchMixin = superClass => class extends superClass {
 
 		const { hits: { hits, total } } = await this.apiClient.searchContent({
 			contentType: 'video',
+			clientApps: clientApps.join(','),
 			createdAt,
 			includeThumbnails: true,
 			query,

--- a/applications/d2l-capture-central/src/state/uploader.js
+++ b/applications/d2l-capture-central/src/state/uploader.js
@@ -150,6 +150,7 @@ export class Uploader {
 			this.runningJobs += 1;
 			const content = await this.apiClient.createContent({
 				title: file.name,
+				clientApp: 'LmsCapture',
 			});
 			const revision = await this.apiClient.createRevision({
 				contentId: content.id,

--- a/applications/d2l-capture-central/src/util/content-service-client.js
+++ b/applications/d2l-capture-central/src/util/content-service-client.js
@@ -176,6 +176,7 @@ export default class ContentServiceClient {
 		sort = 'updatedAt:desc',
 		query = '',
 		contentType = '',
+		clientApps = 'all',
 		updatedAt = '',
 		createdAt = '',
 		includeThumbnails = false
@@ -192,6 +193,7 @@ export default class ContentServiceClient {
 				sort,
 				query,
 				contentType: contentFilterToSearchQuery(contentType),
+				clientApps,
 				updatedAt: dateFilterToSearchQuery(updatedAt),
 				createdAt: dateFilterToSearchQuery(createdAt),
 				includeThumbnails
@@ -206,6 +208,7 @@ export default class ContentServiceClient {
 		sort = 'updatedAt:desc',
 		query = '',
 		contentType = '',
+		clientApps = 'all',
 		updatedAt = '',
 		createdAt = '',
 		includeThumbnails = false
@@ -222,6 +225,7 @@ export default class ContentServiceClient {
 				sort,
 				query,
 				contentType: contentFilterToSearchQuery(contentType),
+				clientApps,
 				updatedAt: dateFilterToSearchQuery(updatedAt),
 				createdAt: dateFilterToSearchQuery(createdAt),
 				filter: 'DELETED',


### PR DESCRIPTION
- videos uploaded from Capture Central now have `clientApp=LmsCapture`
- search now filters out videos with the following clientApp: `LOR`, `Portfolio`, and `VideoNote` 