### PR TITLE
update content after rename or transfer succeeds

### DIFF
--- a/applications/d2l-capture-central/src/components/videos/content-list.js
+++ b/applications/d2l-capture-central/src/components/videos/content-list.js
@@ -94,11 +94,12 @@ class ContentList extends CaptureCentralList {
 			return;
 		}
 
-		const { id, displayName } = detail;
+		const { id, userId, displayName } = detail;
 
 		if (id && displayName) {
 			const index = this._videos.findIndex(c => c.id === id);
 			if (index >= 0 && index < this._videos.length) {
+				this._videos[index].ownerId = userId;
 				this._videos[index].ownerDisplayName = displayName;
 				this._videos[index][this.dateField] = (new Date()).toISOString();
 				this.requestUpdate();


### PR DESCRIPTION
Fixes the issue where renaming a video after transferring ownership reverts the ownership change (https://trello.com/c/63MlfG0D). Also fixes a similar issue where transferring ownership after renaming reverts the name change. 
