### PR TITLE
feat: Bump version for editing timestamp text inputs in Producer

### DIFF
--- a/capture/d2l-capture-producer/src/d2l-video-producer-captions.js
+++ b/capture/d2l-capture-producer/src/d2l-video-producer-captions.js
@@ -191,7 +191,7 @@ class CaptionsCueListItem extends InternalLocalizeMixin(LitElement) {
 	_handleEndTimestampInputTextFocusout() {
 		this.endValidationError = this._handleIsInputValidTimestamp(this.newEndTime);
 		const newEndTimeInSeconds = unformatTimestampText(this.newEndTime);
-		const inputChanged = this.cue.startTime !== newEndTimeInSeconds;
+		const inputChanged = this.cue.endTime !== newEndTimeInSeconds;
 		if (!this.endValidationError && inputChanged) {
 			this.dispatchEvent(new CustomEvent('captions-cue-end-timestamp-edited', {
 				detail: {


### PR DESCRIPTION
I was reviewing the last update in staging and noticed there was one error that somehow got missed. I honestly think I might have clicked control Z or something because I remember going over this on call with Mark. 

It looks like I copy and pasted a line of code in start time focus out to end time focus out and forgot to change a variable name.