### PR TITLE
Uncrop capture view on mobile

### DIFF
--- a/applications/d2l-capture-central/src/components/videos/content-list-header.js
+++ b/applications/d2l-capture-central/src/components/videos/content-list-header.js
@@ -19,6 +19,7 @@ class ContentListHeader extends InternalLocalizeMixin(LitElement) {
 		return [labelStyles, css`
 			:host {
 				font-weight: bold;
+				overflow-wrap: break-word;
 			}
 
 			:host([hidden]) {

--- a/applications/d2l-capture-central/src/components/videos/content-list-item.js
+++ b/applications/d2l-capture-central/src/components/videos/content-list-item.js
@@ -51,6 +51,10 @@ class ContentListItem extends DependencyRequester(navigationMixin(InternalLocali
 			.break-word {
 				overflow-wrap: break-word;
 			}
+
+			.d2l-body-compact {
+				position: relative;
+			}
 		`];
 	}
 

--- a/applications/d2l-capture-central/src/d2l-capture-central-app.js
+++ b/applications/d2l-capture-central/src/d2l-capture-central-app.js
@@ -42,6 +42,7 @@ class D2lCaptureCentralApp extends DependencyRequester(NavigationMixin(InternalL
 			}
 
 			.d2l-capture-central-primary {
+				position: absolute;
 				width: 100%;
 			}
 

--- a/applications/d2l-capture-central/src/d2l-capture-central-app.js
+++ b/applications/d2l-capture-central/src/d2l-capture-central-app.js
@@ -42,7 +42,6 @@ class D2lCaptureCentralApp extends DependencyRequester(NavigationMixin(InternalL
 			}
 
 			.d2l-capture-central-primary {
-				position: absolute;
 				width: 100%;
 			}
 
@@ -85,6 +84,9 @@ class D2lCaptureCentralApp extends DependencyRequester(NavigationMixin(InternalL
 				}
 				d2l-list-item-content d2l-link {
 					display: none;
+				}
+				.d2l-capture-central-primary {
+					position: absolute;
 				}
 			}
 		`];


### PR DESCRIPTION
<img width="423" alt="image" src="https://user-images.githubusercontent.com/34361230/157686126-e24ae729-5b44-42ab-8e13-90fcbe4d1ab0.png">
Headers are broken so it doesn't look the best but it's functional for now. Maybe we can improve the appearance in the future.

https://trello.com/c/B9Hekar2/240-capture-central-android-video-menu-is-cropped-on-android-device