### PR TITLE
Make preview dialog height shorter

### DIFF
--- a/applications/d2l-capture-central/src/d2l-capture-central-app.js
+++ b/applications/d2l-capture-central/src/d2l-capture-central-app.js
@@ -74,6 +74,13 @@ class D2lCaptureCentralApp extends DependencyRequester(NavigationMixin(InternalL
 				margin-top: 25px;
 			}
 
+			#d2l-capture-central-preview {
+				display: flex;
+				height: 100%;
+				min-height: 400px;
+				flex-direction: column;
+			}
+
 			@media (max-width: 1056px) {
 				two-column-layout {
 					--sidebar-width: 200px;
@@ -287,7 +294,7 @@ class D2lCaptureCentralApp extends DependencyRequester(NavigationMixin(InternalL
 				<d2l-capture-central-producer class="page" ?active=${currentPage === pageNames.producer && !!subView}></d2l-capture-central-producer>
 				<d2l-dialog id="preview-dialog" title-text="${this.localize('preview')}">
 					<div id="d2l-preview-div">
-						<d2l-capture-central-preview id="d2l-capture-central-preview" class="page" active></d2l-capture-central-preview>
+						<d2l-capture-central-preview id="d2l-capture-central-preview" active></d2l-capture-central-preview>
 					</div>
 				</d2l-dialog>
 				<d2l-capture-central-settings class="page" ?active=${currentPage === pageNames.settings}></d2l-capture-central-settings>

--- a/applications/d2l-capture-central/src/pages/preview/d2l-capture-central-preview.js
+++ b/applications/d2l-capture-central/src/pages/preview/d2l-capture-central-preview.js
@@ -28,8 +28,7 @@ class D2LCaptureCentralPreview extends DependencyRequester(PageViewElement) {
 
 			d2l-loading-spinner {
 				display: flex;
-				margin: auto;
-				margin-top: 200px;
+				margin-top: 20%;
 			}
 
 			#status-container {


### PR DESCRIPTION
This is what the preview looks like with shorter height:
<img width="952" alt="image" src="https://user-images.githubusercontent.com/34361230/159082855-5f001f2e-abb1-48e8-9f68-fe0525d19e74.png">
<img width="952" alt="image" src="https://user-images.githubusercontent.com/34361230/159082906-d80761c7-fe19-44b7-8fc5-45f64b5f304f.png">
