### PR TITLE
exclude d2l-content-store from tests

### DIFF
--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -1,7 +1,10 @@
 import { playwrightLauncher } from '@web/test-runner-playwright';
 
 function getPattern(type) {
-	return `+(applications|core|capture)/**/*.${type}.js`;
+	return [
+		`+(applications|core|capture)/**/*.${type}.js`,
+		'!applications/d2l-content-store/**/*'
+	];
 }
 
 export default {


### PR DESCRIPTION
d2l-content-store tests, specifically content-list.test.js and content-list-item.test.js were causing other tests to fail with `Error: Uncaught Error: LabelledMixin: "d2l-list-item" is missing a required "label" attribute (node_modules/@brightspace-ui/core/mixins/labelled-mixin.js:208)` because the error is thrown after a delay of 3 seconds. Since we don't use d2l-content-store, excluding these tests to prevent them from causing failures in other tests.

Other places where we use `d2l-list-item` have the `label` attribute or do not require it.