### PR TITLE
fix: Refactor video poster code in Capture Central for clarity

### DIFF
--- a/applications/d2l-capture-central/src/components/capture-central-list.js
+++ b/applications/d2l-capture-central/src/components/capture-central-list.js
@@ -84,8 +84,7 @@ export class CaptureCentralList extends DependencyRequester(InternalLocalizeMixi
 		const { title } = item.content;
 		const { id: revisionId, type } = item.revision;
 		const { id } = item.content;
-		const { ownerDisplayName } = item;
-		const { thumbnail } = item;
+		const { ownerDisplayName, thumbnail } = item;
 		const updatedAt = (new Date()).toISOString();
 
 		await this.insertIntoContentItemsBasedOnSort({

--- a/applications/d2l-capture-central/src/components/capture-central-list.js
+++ b/applications/d2l-capture-central/src/components/capture-central-list.js
@@ -84,11 +84,11 @@ export class CaptureCentralList extends DependencyRequester(InternalLocalizeMixi
 		const { title } = item.content;
 		const { id: revisionId, type } = item.revision;
 		const { id } = item.content;
-		const { ownerDisplayName, thumbnail } = item;
+		const { ownerDisplayName, poster } = item;
 		const updatedAt = (new Date()).toISOString();
 
 		await this.insertIntoContentItemsBasedOnSort({
-			id, revisionId, type, title, ownerDisplayName, updatedAt, thumbnail
+			id, revisionId, type, title, ownerDisplayName, updatedAt, poster
 		});
 	}
 

--- a/applications/d2l-capture-central/src/components/recycle-bin/recycle-bin-item.js
+++ b/applications/d2l-capture-central/src/components/recycle-bin/recycle-bin-item.js
@@ -28,9 +28,9 @@ class RecycleBinItem extends DependencyRequester(navigationMixin(InternalLocaliz
 			disabled: { type: Boolean },
 			dropdownBoundary: { type: Object, attribute: false },
 			id: { type: String },
+			poster: { type: String },
 			revisionId: { type: String, attribute: 'revision-id' },
 			selectable: { type: Boolean },
-			thumbnail: { type: String },
 			title: { type: String },
 			deleted: {type: Boolean},
 		};
@@ -80,8 +80,8 @@ class RecycleBinItem extends DependencyRequester(navigationMixin(InternalLocaliz
 	}
 
 	render() {
-		const illustration = (this.thumbnail && this.thumbnail !== '') ? html`
-			<img class="d2l-capture-central-deleted-poster-image" src="${this.thumbnail}" slot="illustration">
+		const illustration = (this.poster && this.poster !== '') ? html`
+			<img class="d2l-capture-central-deleted-poster-image" src="${this.poster}" slot="illustration">
 		` : html`
 			<d2l-icon icon="tier1:file-video" slot="illustration"></d2l-icon>
 		`;

--- a/applications/d2l-capture-central/src/components/recycle-bin/recycle-bin-list.js
+++ b/applications/d2l-capture-central/src/components/recycle-bin/recycle-bin-list.js
@@ -108,7 +108,7 @@ class RecycleBinList extends CaptureCentralList {
 		<recycle-bin-item
 			id=${item.id}
 			revision-id=${item.revisionId}
-			thumbnail=${ifDefined(item.thumbnail)}
+			poster=${ifDefined(item.poster)}
 			title=${item.title}
 			description=${item.description}
 			@recycle-bin-item-restored=${this.recycleBinItemRestoredHandler}

--- a/applications/d2l-capture-central/src/components/videos/content-list-item.js
+++ b/applications/d2l-capture-central/src/components/videos/content-list-item.js
@@ -34,10 +34,10 @@ class ContentListItem extends DependencyRequester(navigationMixin(InternalLocali
 			disabled: { type: Boolean },
 			dropdownBoundary: { type: Object, attribute: false },
 			id: { type: String },
+			poster: { type: String },
 			revisionId: { type: String, attribute: 'revision-id' },
 			selectable: { type: Boolean },
 			title: { type: String },
-			thumbnail: { type: String },
 			ownerId: { type: String, attribute: 'owner-id' },
 			canTransferOwnership: { type: Boolean, attribute: 'can-transfer-ownership' },
 		};
@@ -96,8 +96,8 @@ class ContentListItem extends DependencyRequester(navigationMixin(InternalLocali
 	}
 
 	render() {
-		const illustration = (this.thumbnail && this.thumbnail !== '') ? html`
-			<img class="d2l-capture-central-video-poster-image" src="${this.thumbnail}" slot="illustration">
+		const illustration = (this.poster && this.poster !== '') ? html`
+			<img class="d2l-capture-central-video-poster-image" src="${this.poster}" slot="illustration">
 		` : html`
 			<d2l-icon icon="tier1:file-video" slot="illustration"></d2l-icon>
 		`;

--- a/applications/d2l-capture-central/src/components/videos/content-list.js
+++ b/applications/d2l-capture-central/src/components/videos/content-list.js
@@ -179,7 +179,7 @@ class ContentList extends CaptureCentralList {
 			revision-id=${item.revisionId}
 			owner-id=${item.ownerId}
 			title=${item.title}
-			thumbnail=${ifDefined(item.thumbnail)}
+			poster=${ifDefined(item.poster)}
 			description=${item.description}
 			?can-transfer-ownership=${this.canTransferOwnership}
 			@content-list-item-renamed=${this.contentListItemRenamedHandler}

--- a/applications/d2l-capture-central/src/mixins/content-search-mixin.js
+++ b/applications/d2l-capture-central/src/mixins/content-search-mixin.js
@@ -132,7 +132,7 @@ export const contentSearchMixin = superClass => class extends superClass {
 				revisionId: result.lastRevId,
 				ownerId: result.ownerId,
 				ownerDisplayName: result.ownerDisplayName,
-				thumbnail: result.thumbnail,
+				poster: result.thumbnail,
 				title: result.title || result.lastRevTitle,
 				type: result.lastRevType,
 				updatedAt: result.updatedAt,

--- a/applications/d2l-capture-central/src/state/uploader.js
+++ b/applications/d2l-capture-central/src/state/uploader.js
@@ -192,13 +192,13 @@ export class Uploader {
 				}
 
 				if (ready && upload.progress === 100) {
-					let thumbnail;
+					let poster;
 					try {
-						thumbnail = (await this.apiClient.getPoster({ contentId: content.id, revisionId: revision.id })).value;
+						poster = (await this.apiClient.getPoster({ contentId: content.id, revisionId: revision.id })).value;
 					} catch (error) {
-						// Ignore if the thumbnail can't be retrieved. An icon will be shown instead of the thumbnail image.
+						// Ignore if the poster can't be retrieved. An icon will be shown instead of the poster image.
 					}
-					this.successfulUpload = { upload, content, revision, thumbnail };
+					this.successfulUpload = { upload, content, revision, poster };
 				}
 			});
 		} catch (error) {


### PR DESCRIPTION
- Combines 2 object destructuring statements into 1.
- Renames all instances of `thumbnail` to `poster`, in order to differentiate the terminology from timeline thumbnails. This also better aligns with the name of the poster resource in Content Service.