### PR TITLE
Incorporating changes to load source video if no formats specified

### DIFF
--- a/core/d2l-content-media-player/d2l-content-media-player.js
+++ b/core/d2l-content-media-player/d2l-content-media-player.js
@@ -11,10 +11,12 @@ import { InternalLocalizeMixin } from './src/mixins/internal-localize-mixin.js';
 const TRACK_ERROR_FETCH_WAIT_MILLISECONDS = 5000;
 const REVISION_POLL_WAIT_MILLISECONDS = 10000;
 const VALID_CONTENT_TYPES = [ContentType.Video, ContentType.Audio];
+const VIDEO_FORMATS_BEST_FIRST = [VideoFormat.HD, VideoFormat.SD, VideoFormat.LD, VideoFormat.MP3];
 
 class ContentMediaPlayer extends InternalLocalizeMixin(LitElement) {
 	static get properties() {
 		return {
+			_bestFormat: { type: String, attribute: false },
 			_captionSignedUrls: { type: Array, attribute: false },
 			_mediaSources: { type: Array, attribute: false },
 			_metadata: { type: String, attribute: false },
@@ -71,6 +73,7 @@ class ContentMediaPlayer extends InternalLocalizeMixin(LitElement) {
 		this._noMediaFound = false;
 		this._error = false;
 		this._playbackSupported = false;
+		this._bestFormat = null;
 	}
 
 	async firstUpdated() {
@@ -214,7 +217,10 @@ class ContentMediaPlayer extends InternalLocalizeMixin(LitElement) {
 	}
 
 	async _loadMedia() {
-		this._mediaSources = await Promise.all(this._revision.formats.map(format => this._getMediaSource(format)));
+		const hasFormats = this._revision.formats && this._revision.formats.length > 0;
+		this._mediaSources = hasFormats ?
+			await Promise.all(this._revision.formats.map(format => this._getMediaSource(format))) :
+			[await this._getMediaSource()];
 	}
 
 	async _loadMetadata() {
@@ -297,7 +303,7 @@ class ContentMediaPlayer extends InternalLocalizeMixin(LitElement) {
 	}
 
 	_renderMediaSource(source) {
-		return html`<source src=${source.src} label=${source.format} ?default=${source.format === VideoFormat.HD}>`;
+		return html`<source src=${source.src} label=${this.localize(`format${source.format || 'Source'}`)} ?default=${source.format === this._bestFormat}>`;
 	}
 
 	async _setup() {

--- a/core/d2l-content-media-player/d2l-content-media-player.js
+++ b/core/d2l-content-media-player/d2l-content-media-player.js
@@ -221,6 +221,11 @@ class ContentMediaPlayer extends InternalLocalizeMixin(LitElement) {
 		this._mediaSources = hasFormats ?
 			await Promise.all(this._revision.formats.map(format => this._getMediaSource(format))) :
 			[await this._getMediaSource()];
+
+		this._bestFormat = this._mediaSources.length > 1 ?
+			VIDEO_FORMATS_BEST_FIRST.find(format =>
+				this._mediaSources.some(mediaSource => mediaSource.format && mediaSource.format === format)
+			) : null;
 	}
 
 	async _loadMetadata() {

--- a/core/d2l-content-media-player/lang/en.js
+++ b/core/d2l-content-media-player/lang/en.js
@@ -5,6 +5,7 @@ export default {
 	formatLD: 'LD',
 	formatMP3: 'MP3',
 	formatSD: 'SD',
+	formatSource: 'Source',
 	generalErrorMessage: 'An error occured while trying to load this resource.',
 	mediaFileIsProcessing: 'This media file is currently being processed. Please come back later.',
 	revisionProcessingFailedMessage: 'An error occured while processing the video. Please try again. Ensure that uploaded files are in a supported format.',


### PR DESCRIPTION
Incorporating recent changes made to d2l-content-viewer to support revisions with no formats (load source video).