### PR TITLE
DE48462 - replace all br tags

### DIFF
--- a/capture/d2l-capture-producer/src/captions-utils.js
+++ b/capture/d2l-capture-producer/src/captions-utils.js
@@ -10,7 +10,7 @@ import { compile as compileWebVTT } from './node-vtt-compiler.js';
 function _convertJsonSrtCuesToVttJsonCues(jsonSrtCues) {
 	return jsonSrtCues.map(jsonSrtCue => {
 		// parse-srt inserts <br /> for line breaks, but WebVTT uses \n.
-		const convertedText = jsonSrtCue.text.replace('<br />', '\n');
+		const convertedText = jsonSrtCue.text.replace(/<br \/>/g, '\n');
 		return {
 			start: jsonSrtCue.start,
 			end: jsonSrtCue.end,

--- a/capture/d2l-capture-producer/test/captions-utils.test.js
+++ b/capture/d2l-capture-producer/test/captions-utils.test.js
@@ -136,7 +136,13 @@ Praesent sollicitudin ac urna sed porttitor.
 3
 00:00:02.000 --> 00:00:03.000
 Nulla massa ante, suscipit nec
-suscipit in, tincidunt et tellus.`;
+suscipit in, tincidunt et tellus.
+
+5
+00:01:02.600 --> 00:01:05.600
+Pellentesque non dictum purus,
+in tincidunt turpis. Quisque at
+ornare tellus.`;
 
 			const expected = `WEBVTT
 
@@ -154,6 +160,11 @@ ultricies non at lacus.
 
 00:01:02.321 --> 00:01:02.600
 Praesent sollicitudin ac urna sed porttitor.
+
+00:01:02.600 --> 00:01:05.600
+Pellentesque non dictum purus,
+in tincidunt turpis. Quisque at
+ornare tellus.
 `;
 
 			const actual = convertSrtTextToVttText(srtFileData);


### PR DESCRIPTION
This fix prevents br tags from being added to the cues in Producer when an srt file is uploaded.
Related to: https://github.com/BrightspaceUILabs/media-player/pull/173