### PR TITLE
Fix mixin - pass in contextType/Id if available

### DIFF
--- a/core/mixins/revision-loader-mixin.js
+++ b/core/mixins/revision-loader-mixin.js
@@ -61,11 +61,12 @@ export const RevisionLoaderMixin = (superClass) => class extends superClass {
 	}
 
 	async _loadRevision() {
+		const httpClient = new ContentServiceBrowserHttpClient({ serviceUrl: this.contentServiceEndpoint });
 		const client = new ContentServiceApiClient({
-			httpClient: new ContentServiceBrowserHttpClient({
-				serviceUrl: this.contentServiceEndpoint
-			}),
-			tenantId: this._tenantId,
+			contextId: this.contextId,
+			contextType: this.contextType,
+			httpClient,
+			tenantId: this._tenantId
 		});
 
 		let revision;


### PR DESCRIPTION
A bug in some refactoring I did yesterday